### PR TITLE
Using Gsettings for info storage, tiedied up some code in the installer and in the scripts

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,4 +1,0 @@
-#!/usr/bin/python
-
-import subprocess
-subprocess.call(['gksudo','python ./scripts/installer.py'])

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+gksu python ./scripts/installer.py

--- a/scripts/apps.elementaryPlusInstaller.gschema.xml
+++ b/scripts/apps.elementaryPlusInstaller.gschema.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="apps.elementaryPlusInstaller" path="/apps/elementaryPlusInstaller/">
+    <key type="as" name="installed">
+      <default>[]</default>
+      <summary>Installed components</summary>
+      <description>List of installed components.</description>
+    </key>
+    <key type="b" name="sniqt-patched">
+      <default>false</default>
+      <summary>Sni-qt patched</summary>
+      <description>True if patched sni-qt installed.</description>
+    </key>
+  </schema>
+</schemalist>

--- a/scripts/core/core.sh
+++ b/scripts/core/core.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-[ "$(whoami)" != "root" ] && exec sudo -- "$0" "$@"
-
 cp -R ../../elementaryPlus /usr/share/icons/
-echo "Core icon theme installed without any errors!"
 exit

--- a/scripts/core/core_remove.sh
+++ b/scripts/core/core_remove.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-[ "$(whoami)" != "root" ] && exec sudo -- "$0" "$@"
-
 rm -rf /usr/share/icons/elementaryPlus
-echo "Core icon theme removed without any errors!"
 exit

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -4,20 +4,37 @@ from gi.repository import Gtk, Gio
 import os.path
 import os
 import sys
+import shutil
+
+curr = os.path.dirname(os.path.realpath(__file__)) + os.sep
+
+if os.path.isfile("/usr/share/glib-2.0/schemas/apps.elementaryPlusInstaller.gschema.xml") == False:
+    srcfile = curr+"apps.elementaryPlusInstaller.gschema.xml"
+    dstdir = "/usr/share/glib-2.0/schemas/"
+    shutil.copy(srcfile, dstdir)
+    os.system("glib-compile-schemas /usr/share/glib-2.0/schemas/")
+    print "schemas copied"
 
 
-options = {
+components = {
     "Core icon theme":"core",
     "MEGAsync":"megasync",
     "Spotify":"spotify",
     "Skype":"skype",
     "OwnCloud":"owncloud"
 }
-installed = "/tmp/elementaryPlus.installed"
-sniqt = "/tmp/sni-qt.patch.installed"
-toinstall = []
-toremove = []
-curr = os.path.dirname(os.path.realpath(__file__)) + os.sep
+
+toInstall = []
+toRemove = []
+
+settings = Gio.Settings.new("apps.elementaryPlusInstaller")
+installedComponents = settings.get_strv("installed")
+patchedSniqt = settings.get_boolean("sniqt-patched")
+#settings.reset("installed")
+#settings.reset("sniqt-patched")
+
+print "Installed components: ", installedComponents
+print "Sni-qt %s patched" % (("IS NOT", "IS")[patchedSniqt])
 
 class confirmDialog(Gtk.Dialog):
 
@@ -28,83 +45,78 @@ class confirmDialog(Gtk.Dialog):
 
         self.set_default_size(200, 100)
 
-        toinstallList = ", ".join([x[0] for x in options.items() if x[1] in toinstall])
-        toremoveList = ", ".join([x[0] for x in options.items() if x[1] in toremove])
-        label_toinstall = Gtk.Label("To install: "+toinstallList)
-        label_toremove = Gtk.Label("To remove: "+toremoveList)
-        label_sep = Gtk.Label(" ")
+        toInstallList = ", ".join([x[0] for x in components.items() if x[1] in toInstall])
+        toRemoveList = ", ".join([x[0] for x in components.items() if x[1] in toRemove])
+        labelToInstall = Gtk.Label("To install: "+toInstallList)
+        labelToRemove = Gtk.Label("To remove: "+toRemoveList)
+        labelSeparator = Gtk.Label(" ")
         label = Gtk.Label("Are you sure you want to appply these changes?")
 
         box = self.get_content_area()
-        if toinstall != []:
-            box.add(label_toinstall)
-        if toremove != []:
-            box.add(label_toremove)
-        box.add(label_sep)
+        if toInstall != []:
+            box.add(labelToInstall)
+        if toRemove != []:
+            box.add(labelToRemove)
+        box.add(labelSeparator)
         box.add(label)
         self.show_all()
 
 class InstallerWindow(Gtk.Window):
 
-    f = open(installed, 'a')
-    f.close()
-
     def callback(self, widget, event, data=None):
-        print "%s was toggled %s" % (data, ("OFF", "ON")[widget.get_active()])
+        installedComponents = settings.get_strv("installed")
+
+        print "\n%s was toggled %s" % (data, ("OFF", "ON")[widget.get_active()])
+
 
         if widget.get_active() == 1:
-            if data not in open(installed).read():
-                toinstall.append(data)
-            elif toremove != [] and data in open(installed).read():
-                toremove.remove(data)
+            if toRemove != [] and data in installedComponents:
+                toRemove.remove(data)
+            elif data not in installedComponents:
+                toInstall.append(data)
         else:
-            if data in open(installed).read():
-                toremove.append(data)
+            if data in installedComponents:
+                toRemove.append(data)
             else:
-                toinstall.remove(data)
+                toInstall.remove(data)
 
-        print "To install: ",toinstall
-        print "To remove: ",toremove
+        print "To install: ",toInstall
+        print "To remove: ",toRemove
 
     def install(self, widget, event, data=None):
 
-        if toinstall != [] or toremove != []:
+        if toInstall != [] or toRemove != []:
             dialog = confirmDialog(self)
             response = dialog.run()
             dialog.destroy()
             if response == Gtk.ResponseType.OK:
-                if toinstall != []:
-                    for data in toinstall:
-                        if data != "core" and os.path.isfile(sniqt) == False:
+                if toInstall != []:
+                    for data in toInstall[:]:
+                        patchedSniqt = settings.get_boolean("sniqt-patched")
+                        if data != "core" and patchedSniqt == False:
                             print "Installing patched sni-qt"
                             os.system("bash ./sni-qt.sh")
-                            f = open(sniqt, 'a')
-                            f.close()
+                            settings.set_boolean("sniqt-patched", True)
 
                         os.chdir(curr+data+"/")
                         os.system("bash ./"+data+".sh")
-                        f = open(installed,"a")
-                        f.write(data+"\n")
-                        f.close()
                         print data+" was installed"
                         os.chdir(curr)
-
-                if toremove != []:
-                    for data in toremove:
+                    mergedInstalledComponents = installedComponents + toInstall
+                    settings.set_strv("installed", mergedInstalledComponents)                      
+                            
+                if toRemove != []:
+                    for data in toRemove[:]:
                         os.chdir(curr+data+"/")
                         os.system("bash ./"+data+"_remove.sh")
-                        f = open(installed,"r")
-                        lines = f.readlines()
-                        f.close()
-                        f = open(installed,"w")
-                        for line in lines:
-                            if line!=data+"\n":
-                                f.write(line)
-
                         print data+" was removed"
                         os.chdir(curr)
-                del toremove[:]
-                del toinstall[:]
+                    installedComponents[:] = [ item for item in installedComponents if item != data ]
+                    settings.set_strv("installed", installedComponents)
+
+                toInstall[:] = []
+                toRemove[:] = []
+
                 dialog = Gtk.MessageDialog(self, 0, Gtk.MessageType.INFO, Gtk.ButtonsType.OK, "All changes applied")
                 dialog.format_secondary_text("Check out your new icons!")
                 dialog.run()
@@ -134,25 +146,25 @@ class InstallerWindow(Gtk.Window):
         installButton.connect("clicked", self.install, "yes")   
         hb.pack_end(installButton)
 
-        lni = len(options.keys())
+        lni = len(components.keys())
         table = Gtk.Table(lni, 3, True)
         table.set_row_spacings(15)
         table.set_col_spacings(10)
         self.add(table)
 
-        for i in range(len(options.keys())):
+        for i in range(len(components.keys())):
 
-            optionLabel = Gtk.Label(options.keys()[i], xalign=0)
+            componentLabel = Gtk.Label(components.keys()[i], xalign=0)
 
-            optionSwitch = Gtk.Switch()
-            optionSwitch.props.halign = Gtk.Align.CENTER
-            optionSwitch.connect("notify::active", self.callback, options.values()[i])
+            componentSwitch = Gtk.Switch()
+            componentSwitch.props.halign = Gtk.Align.CENTER
+            componentSwitch.connect("notify::active", self.callback, components.values()[i])
 
-            if options.values()[i] in open(installed).read():
-                optionSwitch.set_active(True)
+            if components.values()[i] in installedComponents:
+                componentSwitch.set_active(True)
 
-            table.attach(optionLabel, 0, 2, i, i+1)
-            table.attach(optionSwitch, 2, 3, i, i+1)
+            table.attach(componentLabel, 0, 2, i, i+1)
+            table.attach(componentSwitch, 2, 3, i, i+1)
 
 win = InstallerWindow()
 win.connect("delete-event", Gtk.main_quit)

--- a/scripts/megasync/megasync.sh
+++ b/scripts/megasync/megasync.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-[ "$(whoami)" != "root" ] && exec sudo -- "$0" "$@"
-
 mkdir -p /usr/share/sni-qt/icons
 cp ./icons/* /usr/share/sni-qt/icons/
-echo "MEGAsync icons installed without any errors!"
-
 exit

--- a/scripts/megasync/megasync_remove.sh
+++ b/scripts/megasync/megasync_remove.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
-[ "$(whoami)" != "root" ] && exec sudo -- "$0" "$@"
-
 for entry in icons/*
 do
   echo "$entry"
   rm /usr/share/sni-qt/$entry
 done
-
-echo "MEGAsync icons removed without any errors!"
-
 exit

--- a/scripts/owncloud/owncloud.sh
+++ b/scripts/owncloud/owncloud.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-[ "$(whoami)" != "root" ] && exec sudo -- "$0" "$@"
-
 mkdir -p /usr/share/sni-qt/icons
 cp ./icons/* /usr/share/sni-qt/icons/
-echo "Owncloud icons installed without any errors!"
 exit

--- a/scripts/owncloud/owncloud_remove.sh
+++ b/scripts/owncloud/owncloud_remove.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-[ "$(whoami)" != "root" ] && exec sudo -- "$0" "$@"
-
 for entry in icons/*
 do
   echo "$entry"
   rm /usr/share/sni-qt/$entry
 done
-echo "Owncloud icons removed without any errors!"
 exit

--- a/scripts/skype/skype.sh
+++ b/scripts/skype/skype.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-[ "$(whoami)" != "root" ] && exec sudo -- "$0" "$@"
-
 mkdir -p /usr/share/sni-qt/icons
 cp ./icons/* /usr/share/sni-qt/icons/
-echo "Skype icons installed without any errors!"
 exit

--- a/scripts/skype/skype_remove.sh
+++ b/scripts/skype/skype_remove.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-[ "$(whoami)" != "root" ] && exec sudo -- "$0" "$@"
-
 for entry in icons/*
 do
   echo "$entry"
   rm /usr/share/sni-qt/$entry
 done
-echo "Skype icons removed without any errors!"
 exit

--- a/scripts/sni-qt.sh
+++ b/scripts/sni-qt.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-[ "$(whoami)" != "root" ] && exec sudo -- "$0" "$@"
-
 add-apt-repository --yes ppa:rpeshkov/ppa
 apt-get -y update
-apt-get -y upgrade
+apt-get -y install sni-qt
 add-apt-repository --remove --yes ppa:rpeshkov/ppa

--- a/scripts/spotify/spotify.sh
+++ b/scripts/spotify/spotify.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-[ "$(whoami)" != "root" ] && exec sudo -- "$0" "$@"
-
 mkdir -p /usr/share/sni-qt/icons
 cp ./icons/* /usr/share/sni-qt/icons/
-echo "Spotify icon installed without any errors!"
 exit

--- a/scripts/spotify/spotify_remove.sh
+++ b/scripts/spotify/spotify_remove.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-[ "$(whoami)" != "root" ] && exec sudo -- "$0" "$@"
-
 for entry in icons/*
 do
   echo "$entry"
   rm /usr/share/sni-qt/$entry
 done
-echo "Spotify icon removed without any errors!"
 exit


### PR DESCRIPTION
The settings will not show in dconf-editor (as expected) because we're required to run the installer as root. Personally, I think it's good that they don't show up there because the user should not be able to change the "Installed" list.