### PR TITLE
Create symbolic links if installed from the PPA

### DIFF
--- a/scripts/elementaryplus-installer.py
+++ b/scripts/elementaryplus-installer.py
@@ -424,6 +424,7 @@ class InstallerWindow(Gtk.Window):
                                 settings.set_boolean("sniqt-patched", True)
 
                         out = check_output(['bash', scripts + data + "/setup.sh", "--install"])
+                        print out
                         if out[:1] is "F":
                             print "Passed"
                             error = True
@@ -454,6 +455,7 @@ class InstallerWindow(Gtk.Window):
                 if len(toRemove) != 0:
                     for data in toRemove[:]:
                         out = check_output(['bash', scripts + data + "/setup.sh", "--remove"])
+                        print out
                         if out[:1] is "F":
                             print "Passed"
                             error = True

--- a/scripts/flareget/setup.sh
+++ b/scripts/flareget/setup.sh
@@ -4,10 +4,19 @@ cd $DIR
 
 sniqtPrefix="flareget"
 
+source ../whattouse.sh
+
 if [ $1 == "--install" ]
     then
+        rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix
         mkdir -p ~/.local/share/sni-qt/icons/$sniqtPrefix
-        cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        if [ $whatToUse == "cp" ]
+            then
+                cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        elif [ $whatToUse == "ln" ]
+            then
+                ln -sf $DIR/icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        fi
 elif [ $1 == "--remove" ]
     then
         rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix

--- a/scripts/google_music_manager/setup.sh
+++ b/scripts/google_music_manager/setup.sh
@@ -4,10 +4,19 @@ cd $DIR
 
 sniqtPrefix="MusicManager"
 
+source ../whattouse.sh
+
 if [ $1 == "--install" ]
     then
+        rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix
         mkdir -p ~/.local/share/sni-qt/icons/$sniqtPrefix
-        cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        if [ $whatToUse == "cp" ]
+            then
+                cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        elif [ $whatToUse == "ln" ]
+            then
+                ln -sf $DIR/icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        fi
 elif [ $1 == "--remove" ]
     then
         rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix

--- a/scripts/hp_linux_printing_and_imaging/setup.sh
+++ b/scripts/hp_linux_printing_and_imaging/setup.sh
@@ -4,10 +4,19 @@ cd $DIR
 
 sniqtPrefix="python2.7"
 
+source ../whattouse.sh
+
 if [ $1 == "--install" ]
     then
+        rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix
         mkdir -p ~/.local/share/sni-qt/icons/$sniqtPrefix
-        cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        if [ $whatToUse == "cp" ]
+            then
+                cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        elif [ $whatToUse == "ln" ]
+            then
+                ln -sf $DIR/icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        fi
 elif [ $1 == "--remove" ]
     then
         rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix

--- a/scripts/megasync/setup.sh
+++ b/scripts/megasync/setup.sh
@@ -4,10 +4,19 @@ cd $DIR
 
 sniqtPrefix="megasync"
 
+source ../whattouse.sh
+
 if [ $1 == "--install" ]
     then
+        rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix
         mkdir -p ~/.local/share/sni-qt/icons/$sniqtPrefix
-        cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        if [ $whatToUse == "cp" ]
+            then
+                cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        elif [ $whatToUse == "ln" ]
+            then
+                ln -sf $DIR/icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        fi
 elif [ $1 == "--remove" ]
     then
         rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix

--- a/scripts/mumble/setup.sh
+++ b/scripts/mumble/setup.sh
@@ -4,10 +4,19 @@ cd $DIR
 
 sniqtPrefix="mumble"
 
+source ../whattouse.sh
+
 if [ $1 == "--install" ]
     then
+        rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix
         mkdir -p ~/.local/share/sni-qt/icons/$sniqtPrefix
-        cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        if [ $whatToUse == "cp" ]
+            then
+                cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        elif [ $whatToUse == "ln" ]
+            then
+                ln -sf $DIR/icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        fi
 elif [ $1 == "--remove" ]
     then
         rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix

--- a/scripts/owncloud/setup.sh
+++ b/scripts/owncloud/setup.sh
@@ -4,10 +4,19 @@ cd $DIR
 
 sniqtPrefix="owncloud"
 
+source ../whattouse.sh
+
 if [ $1 == "--install" ]
     then
+        rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix
         mkdir -p ~/.local/share/sni-qt/icons/$sniqtPrefix
-        cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        if [ $whatToUse == "cp" ]
+            then
+                cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        elif [ $whatToUse == "ln" ]
+            then
+                ln -sf $DIR/icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        fi
 elif [ $1 == "--remove" ]
     then
         rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix

--- a/scripts/seafile_client/setup.sh
+++ b/scripts/seafile_client/setup.sh
@@ -4,10 +4,19 @@ cd $DIR
 
 sniqtPrefix="seafile-applet"
 
+source ../whattouse.sh
+
 if [ $1 == "--install" ]
     then
+        rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix
         mkdir -p ~/.local/share/sni-qt/icons/$sniqtPrefix
-        cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        if [ $whatToUse == "cp" ]
+            then
+                cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        elif [ $whatToUse == "ln" ]
+            then
+                ln -sf $DIR/icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        fi
 elif [ $1 == "--remove" ]
     then
         rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix

--- a/scripts/skype/setup.sh
+++ b/scripts/skype/setup.sh
@@ -4,10 +4,19 @@ cd $DIR
 
 sniqtPrefix="skype"
 
+source ../whattouse.sh
+
 if [ $1 == "--install" ]
     then
+        rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix
         mkdir -p ~/.local/share/sni-qt/icons/$sniqtPrefix
-        cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        if [ $whatToUse == "cp" ]
+            then
+                cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        elif [ $whatToUse == "ln" ]
+            then
+                ln -sf $DIR/icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        fi
 elif [ $1 == "--remove" ]
     then
         rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix

--- a/scripts/spotify/setup.sh
+++ b/scripts/spotify/setup.sh
@@ -4,6 +4,8 @@ cd $DIR
 
 sniqtPrefix="spotify"
 
+source ../whattouse.sh
+
 if [ $1 == "--install" ]
     then
         curr=`pwd`
@@ -16,8 +18,15 @@ if [ $1 == "--install" ]
             filename="${filename%.*}"
             uuid=`cut -d '_' -f3 <<< $filename`
             cd $curr
+            rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix
             mkdir -p ~/.local/share/sni-qt/icons/$sniqtPrefix
-            cp ./icons/icon.png ~/.local/share/sni-qt/icons/$sniqtPrefix/$uuid.png
+            if [ $whatToUse == "cp" ]
+                then
+                    cp ./icons/icon.png ~/.local/share/sni-qt/icons/$sniqtPrefix/$uuid.png
+            elif [ $whatToUse == "ln" ]
+                then
+                    ln -sf $DIR/icons/icon.png ~/.local/share/sni-qt/icons/$sniqtPrefix/$uuid.png
+            fi
         else
             echo "Failed"
             notify-send "Failed to install Spotify icons" "Please run Spotify and try again" -i "preferences-desktop"

--- a/scripts/telegram_desktop/setup.sh
+++ b/scripts/telegram_desktop/setup.sh
@@ -3,18 +3,31 @@ DSTDIR=~/.TelegramDesktop/tdata/ticons
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 cd $DIR
 
-if [ $1 == "--install" ]
-	then
-		cp ./icons/*.png $DSTDIR
-		ln -sf $DSTDIR/ico_22_0.png $DSTDIR/icomute_22_0.png
+source ../whattouse.sh
 
-		for((i=2; i<100; i++))
-			do
-				ln -sf $DSTDIR/ico_22_1.png $DSTDIR/ico_22_$i.png
-				ln -sf $DSTDIR/ico_22_1.png $DSTDIR/icomute_22_$i.png
-			done
+if [ $1 == "--install" ]
+    then
+        if [ $whatToUse == "cp" ]
+            then
+                cp ./icons/*.png $DSTDIR
+                ln -sf $DSTDIR/ico_22_0.png $DSTDIR/icomute_22_0.png
+                for((i=2; i<100; i++))
+                    do
+                        ln -sf $DSTDIR/ico_22_1.png $DSTDIR/ico_22_$i.png
+                        ln -sf $DSTDIR/ico_22_1.png $DSTDIR/icomute_22_$i.png
+                    done
+        elif [ $whatToUse == "ln" ]
+            then
+                ln -sf $DIR/icons/*.png $DSTDIR
+                ln -sf $DIR/icons/ico_22_0.png $DSTDIR/icomute_22_0.png
+                for((i=2; i<100; i++))
+                    do
+                        ln -sf $DIR/icons/ico_22_1.png $DSTDIR/ico_22_$i.png
+                        ln -sf $DIR/icons/ico_22_1.png $DSTDIR/icomute_22_$i.png
+                    done
+        fi
 elif [ $1 == "--remove" ]
-	then
-		rm $DSTDIR/*.png
+    then
+        rm $DSTDIR/*.png
 fi
 exit

--- a/scripts/tomahawk/setup.sh
+++ b/scripts/tomahawk/setup.sh
@@ -4,10 +4,19 @@ cd $DIR
 
 sniqtPrefix="tomahawk"
 
+source ../whattouse.sh
+
 if [ $1 == "--install" ]
     then
+        rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix
         mkdir -p ~/.local/share/sni-qt/icons/$sniqtPrefix
-        cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        if [ $whatToUse == "cp" ]
+            then
+                cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        elif [ $whatToUse == "ln" ]
+            then
+                ln -sf $DIR/icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        fi
 elif [ $1 == "--remove" ]
     then
         rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix

--- a/scripts/whattouse.sh
+++ b/scripts/whattouse.sh
@@ -1,0 +1,1 @@
+whatToUse="ln"

--- a/scripts/whattouse.sh
+++ b/scripts/whattouse.sh
@@ -1,1 +1,1 @@
-whatToUse="ln"
+whatToUse="cp"

--- a/scripts/whattouse.sh~
+++ b/scripts/whattouse.sh~
@@ -1,1 +1,0 @@
-whatToUse="cp"

--- a/scripts/whattouse.sh~
+++ b/scripts/whattouse.sh~
@@ -1,0 +1,1 @@
+whatToUse="ln"

--- a/scripts/whattouse.sh~
+++ b/scripts/whattouse.sh~
@@ -1,0 +1,1 @@
+whatToUse="cp"

--- a/scripts/whattouse.sh~
+++ b/scripts/whattouse.sh~
@@ -1,1 +1,0 @@
-whatToUse="ln"

--- a/scripts/wiznote/setup.sh
+++ b/scripts/wiznote/setup.sh
@@ -4,10 +4,19 @@ cd $DIR
 
 sniqtPrefix="WizNote"
 
+source ../whattouse.sh
+
 if [ $1 == "--install" ]
     then
+        rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix
         mkdir -p ~/.local/share/sni-qt/icons/$sniqtPrefix
-        cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        if [ $whatToUse == "cp" ]
+            then
+                cp ./icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        elif [ $whatToUse == "ln" ]
+            then
+                ln -sf $DIR/icons/* ~/.local/share/sni-qt/icons/$sniqtPrefix
+        fi
 elif [ $1 == "--remove" ]
     then
         rm -rf ~/.local/share/sni-qt/icons/$sniqtPrefix


### PR DESCRIPTION
The installer will now create symbolic links when installed from the PPA.
`/home/user/.local/share/sni-qt/icons/appName/iconName.png`
points to
`/usr/share/elementaryPlus/scripts/appName/iconName.png`
This will enable us to seamlessly update sni-qt indicator icons.