### PR TITLE
Link synaptic

### DIFF
--- a/elementaryPlus/apps/128/synaptic.svg
+++ b/elementaryPlus/apps/128/synaptic.svg
@@ -1,0 +1,1 @@
+/usr/share/icons/elementary/apps/128/system-software-installer.svg

--- a/elementaryPlus/apps/16/synaptic.svg
+++ b/elementaryPlus/apps/16/synaptic.svg
@@ -1,0 +1,1 @@
+/usr/share/icons/elementary/apps/16/system-software-installer.svg

--- a/elementaryPlus/apps/24/synaptic.svg
+++ b/elementaryPlus/apps/24/synaptic.svg
@@ -1,0 +1,1 @@
+/usr/share/icons/elementary/apps/24/system-software-installer.svg

--- a/elementaryPlus/apps/32/synaptic.svg
+++ b/elementaryPlus/apps/32/synaptic.svg
@@ -1,0 +1,1 @@
+/usr/share/icons/elementary/apps/32/system-software-installer.svg

--- a/elementaryPlus/apps/48/synaptic.svg
+++ b/elementaryPlus/apps/48/synaptic.svg
@@ -1,0 +1,1 @@
+/usr/share/icons/elementary/apps/48/system-software-installer.svg

--- a/elementaryPlus/apps/64/synaptic.svg
+++ b/elementaryPlus/apps/64/synaptic.svg
@@ -1,0 +1,1 @@
+/usr/share/icons/elementary/apps/64/system-software-installer.svg

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd "$(dirname "$0")"
 if [[ $EUID -ne 0 ]]; then
     ./scripts/elementaryplus-installer.py
 else
@@ -6,4 +7,3 @@ else
    echo "Please run again as normal user." 1>&2
 fi
 exit
-


### PR DESCRIPTION
I have decided to symlink the Synaptic to the AppCenter icons, as long as there is no actual AppCenter in Freya this is by far better than the stock icon. 

Also a little modification of `install.sh` so you don't actually have to be in the elementaryPlus directory to run it. Only tested with the git version, I hope this does not have any effects on the packaged version.