### PR TITLE
Add updated Spotify icon, fixes #388

### DIFF
--- a/elementaryPlus/apps/128/spotify-client.svg
+++ b/elementaryPlus/apps/128/spotify-client.svg
@@ -11,11 +11,11 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   width="48"
-   height="48"
-   id="svg4031"
+   width="128"
+   height="128"
+   id="svg5157"
    inkscape:version="0.48.4 r9939"
-   sodipodi:docname="circleicon48.svg">
+   sodipodi:docname="circleicon128.svg">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -27,172 +27,163 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1025"
-     id="namedview48"
+     id="namedview42"
      showgrid="false"
      inkscape:zoom="1"
-     inkscape:cx="-174.48972"
-     inkscape:cy="213.28061"
+     inkscape:cx="13.933231"
+     inkscape:cy="34.198828"
      inkscape:window-x="0"
      inkscape:window-y="30"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg4031" />
+     inkscape:current-layer="svg5157" />
   <defs
-     id="defs4033">
+     id="defs5159">
     <linearGradient
-       id="linearGradient4168">
+       id="linearGradient4246">
       <stop
-         id="stop4170"
-         style="stop-color:#f8b17e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4172"
-         style="stop-color:#e35d4f;stop-opacity:1"
-         offset="0.23208089" />
-      <stop
-         id="stop4174"
-         style="stop-color:#c6262e;stop-opacity:1"
-         offset="0.5908742" />
-      <stop
-         id="stop4176"
-         style="stop-color:#690b54;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3957">
-      <stop
-         id="stop3959"
+         id="stop4248"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3961"
-         style="stop-color:#c1c1c1;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4011">
-      <stop
-         id="stop4013"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4015"
+         id="stop4250"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.507761" />
+         offset="0.23521248" />
       <stop
-         id="stop4017"
+         id="stop4252"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.83456558" />
+         offset="0.76404774" />
       <stop
-         id="stop4019"
+         id="stop4254"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
+       id="linearGradient3242-7-3-8-9-0-2">
       <stop
-         id="stop3750-8-9"
-         style="stop-color:#bebebe;stop-opacity:1;"
+         id="stop3244-5-8-5-3-4-4"
+         style="stop-color:#eef87e;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3752-3-2"
+         id="stop3246-9-5-1-2-5-3"
+         style="stop-color:#cde34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7-2-0-84-2-0"
+         style="stop-color:#93b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8-2-8-3-3-4"
+         style="stop-color:#5a7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="299.44821"
+       cy="-290.5918"
+       r="17.1528"
+       fx="297.44989"
+       fy="-289.9133"
+       id="XMLID_2_-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8232,0.2312,0.2703,-0.9626,-96.2274,-315.3433)">
+      <stop
+         id="stop228-2"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop230-7"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-6">
+      <stop
+         id="stop3750-8-9-0"
+         style="stop-color:#a4a4a4;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3752-3-2-8"
          style="stop-color:#969696;stop-opacity:1;"
          offset="0.26238" />
       <stop
-         id="stop3754-7-2"
+         id="stop3754-7-2-7"
          style="stop-color:#8e8e8e;stop-opacity:1;"
          offset="0.704952" />
       <stop
-         id="stop3756-9-3"
+         id="stop3756-9-3-6"
          style="stop-color:#666666;stop-opacity:1;"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3820-7-2-1">
+       id="linearGradient3820-7-2-8-6">
       <stop
-         id="stop3822-2-6-3"
+         id="stop3822-2-6-5-0"
          style="stop-color:#3d3d3d;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3864-8-7-7"
+         id="stop3864-8-7-4-1"
          style="stop-color:#686868;stop-opacity:0.49803922"
          offset="0.5" />
       <stop
-         id="stop3824-1-2-5"
+         id="stop3824-1-2-6-7"
          style="stop-color:#686868;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
        x1="71.204407"
-       y1="6.2375584"
+       y1="6.8949885"
        x2="71.204407"
-       y2="44.340794"
-       id="linearGradient3012"
-       xlink:href="#linearGradient4011"
+       y2="44.00914"
+       id="linearGradient5267"
+       xlink:href="#linearGradient4246"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611001,-2.7279009)" />
+       gradientTransform="matrix(2.7567564,0,0,2.7567564,-133.25186,-67.905563)" />
     <radialGradient
-       cx="3.9722471"
-       cy="8.4497671"
+       cx="18.164446"
+       cy="8.449769"
        r="19.99999"
-       fx="3.9722471"
-       fy="8.4497671"
-       id="radialGradient3015"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-9"
+       fx="8.894803"
+       fy="8.5985041"
+       id="radialGradient5270"
+       xlink:href="#linearGradient3242-7-3-8-9-0-2"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,2.4988347,-2.6434689,-6.8014435e-8,46.336814,-12.180468)" />
+       gradientTransform="matrix(0,3.5027864,-3.3090405,-4.0448548e-8,92.459105,-62.015358)" />
+    <linearGradient
+       x1="-1085.9586"
+       y1="539.40955"
+       x2="-474.68497"
+       y2="375.61926"
+       id="linearGradient5275"
+       xlink:href="#XMLID_2_-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17796026,0,0,0.14954125,216.71264,-67.15218)" />
+    <radialGradient
+       cx="15.645058"
+       cy="8.449769"
+       r="19.99999"
+       fx="-0.12323578"
+       fy="8.44977"
+       id="radialGradient5279"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.7030133e-7,2.7986346,-2.6367191,-1.9276587e-7,86.77997,-49.34197)" />
     <radialGradient
        cx="99.157013"
        cy="186.17059"
        r="62.769119"
        fx="99.157013"
        fy="186.17059"
-       id="radialGradient3018"
-       xlink:href="#linearGradient3820-7-2-1"
+       id="radialGradient5282"
+       xlink:href="#linearGradient3820-7-2-8-6"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.27083381,0,0,0.08762273,-2.855072,25.187228)" />
-    <linearGradient
-       x1="27.92535"
-       y1="15.149301"
-       x2="33.447899"
-       y2="22.986004"
-       id="linearGradient3951"
-       xlink:href="#linearGradient4168"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       x1="24"
-       y1="22"
-       x2="24"
-       y2="26"
-       id="linearGradient3963"
-       xlink:href="#linearGradient3957"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       x1="21.013996"
-       y1="25.433903"
-       x2="22.805599"
-       y2="27.343702"
-       id="linearGradient3963-7"
-       xlink:href="#linearGradient3957-2"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3957-2">
-      <stop
-         id="stop3959-62"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3961-5"
-         style="stop-color:#c1c1c1;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
+       gradientTransform="matrix(1,0,0,0.1666667,0,155.14216)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4011"
-       id="linearGradient3801"
-       x1="16.415949"
-       y1="-2.6000259"
-       x2="16.415949"
-       y2="37.600647"
+       xlink:href="#linearGradient4246"
+       id="linearGradient3795"
+       x1="65.727997"
+       y1="14.893266"
+       x2="65.727997"
+       y2="117.75234"
        gradientUnits="userSpaceOnUse" />
     <radialGradient
        cx="99.157013"
@@ -226,25 +217,25 @@
        fx="-0.22334664"
        fy="8.44977"
        id="radialGradient5007"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-9"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(-9.6613255e-8,1.5876869,-1.495831,-1.0935756e-7,44.6396,2.8743392)" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-9">
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
       <stop
-         id="stop3750-8-9-2"
+         id="stop3750-8-9"
          style="stop-color:#8de53e;stop-opacity:1;"
          offset="0" />
       <stop
-         id="stop3752-3-2-1"
+         id="stop3752-3-2"
          style="stop-color:#95de55;stop-opacity:1;"
          offset="0.26238" />
       <stop
-         id="stop3754-7-2-0"
+         id="stop3754-7-2"
          style="stop-color:#82de31;stop-opacity:1;"
          offset="0.704952" />
       <stop
-         id="stop3756-9-3-4"
+         id="stop3756-9-3"
          style="stop-color:#60cc00;stop-opacity:1;"
          offset="1" />
     </linearGradient>
@@ -278,7 +269,7 @@
     </linearGradient>
   </defs>
   <metadata
-     id="metadata4036">
+     id="metadata5162">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -290,37 +281,45 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="g3872">
+     id="g3895">
     <g
-       id="g3803">
-      <path
-         d="m 40.999999,41.499999 a 17,5.4999999 0 1 1 -33.999999,0 17,5.4999999 0 1 1 33.999999,0 z"
-         id="path3818-0-5"
-         style="fill:url(#radialGradient3018);fill-opacity:1;stroke:none" />
-      <path
-         d="M 24.000003,3.4999982 C 12.68881,3.4999982 3.4999996,12.688804 3.4999996,23.999998 3.4999996,35.311192 12.68881,44.500003 24.000003,44.5 35.311191,44.5 44.500011,35.311192 44.5,23.999998 44.5,12.688804 35.311191,3.4999982 24.000003,3.4999982 z"
-         id="path2555"
-         style="color:#000000;fill:url(#radialGradient3015);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         d="m 24.000003,3.499998 c -11.311193,0 -20.5000034,9.188806 -20.5000034,20.5 0,11.311194 9.1888104,20.500005 20.5000034,20.500002 11.311188,0 20.500008,-9.188808 20.499997,-20.500002 0,-11.311194 -9.188809,-20.5 -20.499997,-20.5 z"
-         id="path2555-6"
-         style="opacity:0.4;color:#000000;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       id="g3797">
+      <g
+         transform="translate(0,64)"
+         id="layer1">
+        <path
+           d="m 161.92613,186.17059 a 62.769119,10.461519 0 1 1 -125.538236,0 62.769119,10.461519 0 1 1 125.538236,0 z"
+           transform="matrix(0.6869404,0,0,1.2877013,-4.02174,-195.20343)"
+           id="path3818-0-5-0"
+           style="fill:url(#radialGradient5282);fill-opacity:1;stroke:none" />
+        <path
+           d="m 64.5,-50.001824 c -28.691795,0 -52,23.30819 -52,51.9999979 0,28.6918081 23.308205,52.0000141 52,52.0000041 28.6918,0 52.00001,-23.308196 52,-52.0000041 0,-28.6918079 -23.3082,-51.9999979 -52,-51.9999979 z"
+           inkscape:connector-curvature="0"
+           id="path2555-7-6"
+           style="color:#000000;fill:url(#radialGradient5279);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+        <path
+           d="M 116.5,1.9963279 C 116.5,30.716059 93.217097,53.998178 64.500664,53.998178 35.781595,53.998178 12.5,30.715795 12.5,1.9963279 12.5,-26.722075 35.781595,-50.001822 64.500664,-50.001822 93.217097,-50.001822 116.5,-26.722075 116.5,1.9963279 l 0,0 z"
+           inkscape:connector-curvature="0"
+           id="path8655-6-1"
+           style="opacity:0.4;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999994000000003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      </g>
       <path
          sodipodi:type="arc"
-         style="opacity:0.40000000000000002;fill:none;stroke:url(#linearGradient3801);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         id="path3025"
-         sodipodi:cx="16.539108"
-         sodipodi:cy="17.510515"
-         sodipodi:rx="19.487383"
-         sodipodi:ry="19.487383"
-         d="m 36.026491,17.510515 a 19.487383,19.487383 0 1 1 -38.9747656,0 19.487383,19.487383 0 1 1 38.9747656,0 z"
-         transform="translate(7.4608917,6.4894848)" />
+         style="opacity:0.40000000000000002;fill:none;stroke:url(#linearGradient3795);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path3019"
+         sodipodi:cx="65.772919"
+         sodipodi:cy="66.445755"
+         sodipodi:rx="51.007568"
+         sodipodi:ry="51.007568"
+         d="m 116.78049,66.445755 a 51.007568,51.007568 0 1 1 -102.01514,0 51.007568,51.007568 0 1 1 102.01514,0 z"
+         transform="translate(-1.2729187,-0.447578)" />
     </g>
     <g
-       transform="matrix(0.7,0,0,0.7,1.4207116,1.7052129)"
-       id="g3882">
+       transform="translate(2.5,1.4142136)"
+       id="g3885">
       <g
-         id="g3869">
+         id="g3869"
+         transform="matrix(1.7860197,0,0,1.7860197,4.1901033,7.1142834)">
         <path
            sodipodi:nodetypes="sssssssss"
            inkscape:connector-curvature="0"
@@ -341,25 +340,25 @@
            style="opacity:0.9;fill:#1a1a1a;fill-opacity:1;stroke:none" />
       </g>
       <g
-         id="g3874"
-         style="opacity:0.2;fill:#ffffff"
-         transform="translate(0,1.4142136)">
+         transform="matrix(1.7860197,0,0,1.7860197,4.1901033,8.9359822)"
+         id="g3877"
+         style="opacity:0.2;fill:#ffffff">
         <path
            style="opacity:0.9;fill:#ffffff;fill-opacity:1;stroke:none"
            d="m 17.298088,40.902181 c 0.5927,-2.211986 2.511307,-2.908051 4.505133,-2.908051 3.046229,0 6.075666,0.293311 8.946667,1.062595 2.871,0.769281 5.750306,2.092963 8.279337,3.553099 1.726704,0.996913 2.991573,2.740627 2.412776,4.900726 -0.44672,1.667187 -2.298784,2.114913 -4.025488,1.117998 -2.504852,-1.446176 -5.408337,-2.783817 -8.279338,-3.553099 -2.871001,-0.769284 -5.985761,-1.062595 -8.946666,-1.062595 -1.993826,0 -3.339143,-1.443486 -2.892421,-3.110673 z"
-           id="path3876"
+           id="path3879"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="sssssssss" />
         <path
            sodipodi:nodetypes="sssssssss"
            inkscape:connector-curvature="0"
-           id="path3878"
+           id="path3881"
            d="m 14.48274,30.10568 c 0.592699,-2.211984 2.511306,-2.90805 4.505132,-2.908051 3.046229,1e-6 8.414615,0.369513 14.734347,2.06288 5.80609,1.555737 10.715029,3.816484 13.24406,5.276623 1.726704,0.996912 2.991575,2.740624 2.412777,4.900724 -0.446721,1.667187 -2.298785,2.114913 -4.025488,1.118 C 42.848715,39.10968 38.062352,36.874294 32.109506,35.279234 26.523547,33.78248 20.336065,33.216355 17.37516,33.216355 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110675 z"
            style="opacity:0.9;fill:#ffffff;fill-opacity:1;stroke:none" />
         <path
            style="opacity:0.9;fill:#ffffff;fill-opacity:1;stroke:none"
            d="m 12.346123,19.69258 c 0.592699,-2.211986 2.511306,-2.908051 4.505132,-2.908051 3.046229,0 11.800505,0.647594 19.147517,2.61622 9.3282,2.499482 14.192548,5.220155 16.72158,6.680294 1.726704,0.996912 2.991572,2.740624 2.412776,4.900724 -0.446721,1.667186 -2.298785,2.114913 -4.02549,1.117999 C 48.602789,30.653589 40.045396,26.935888 34.38606,25.419475 27.99295,23.706446 18.199449,22.803253 15.238543,22.803253 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110673 z"
-           id="path3880"
+           id="path3883"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="sssssssss" />
       </g>

--- a/elementaryPlus/apps/16/spotify-client.svg
+++ b/elementaryPlus/apps/16/spotify-client.svg
@@ -1,0 +1,1350 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg3816"
+   inkscape:version="0.91 r"
+   sodipodi:docname="circleicon16.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1025"
+     id="namedview221"
+     showgrid="false"
+     showborder="true"
+     inkscape:zoom="22.627417"
+     inkscape:cx="11.26772"
+     inkscape:cy="10.282422"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3816" />
+  <defs
+     id="defs3818">
+    <linearGradient
+       id="linearGradient6303-33-0-2-0-0">
+      <stop
+         id="stop6305-1-0-2-0-2"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6307-5-0-6-1-8"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6303-3-2-1-4-9">
+      <stop
+         id="stop6305-3-0-9-0-0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6307-1-0-1-2-1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6303-4-8-5-0">
+      <stop
+         id="stop6305-33-3-3-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6307-9-3-4-0"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6088-6-1-0-06-8">
+      <stop
+         id="stop6090-2-0-4-9-4"
+         style="stop-color:#ff54d2;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop6257-4-6-1-76-0"
+         style="stop-color:#ff54d2;stop-opacity:0"
+         offset="0.32368398" />
+      <stop
+         id="stop6255-3-6-7-23-8"
+         style="stop-color:#ff54d2;stop-opacity:0.2521739"
+         offset="0.56140333" />
+      <stop
+         id="stop6092-9-6-8-9-2"
+         style="stop-color:#ff54d2;stop-opacity:0.47826087"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6191-8-3-4-5-4">
+      <stop
+         id="stop6193-75-7-6-4-2"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop6197-3-4-1-4-8"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.40531859" />
+      <stop
+         id="stop6195-7-2-5-7-8"
+         style="stop-color:#ffffff;stop-opacity:0.47826087"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6191-7-9-4-9-2">
+      <stop
+         id="stop6193-7-3-6-0-5"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop6197-2-2-0-4-9"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.40531859" />
+      <stop
+         id="stop6195-2-1-9-1-9"
+         style="stop-color:#ffffff;stop-opacity:0.47826087"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6191-9-9-5-0">
+      <stop
+         id="stop6193-8-1-3-2"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop6197-8-8-7-1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.40531859" />
+      <stop
+         id="stop6195-9-3-6-0"
+         style="stop-color:#ffffff;stop-opacity:0.47826087"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3990-3-1-7-0-9">
+      <stop
+         id="stop3992-0-0-1-0-0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3994-2-1-8-6-6"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4316-4-6-6-4-5-1">
+      <stop
+         id="stop4318-4-4-6-5-3-0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4320-2-2-6-59-35-1"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.33799788" />
+      <stop
+         id="stop4322-4-5-5-0-1-8"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.61996669" />
+      <stop
+         id="stop4324-4-1-5-5-42-0"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6088-74-4-8-8">
+      <stop
+         id="stop6090-5-66-7-7"
+         style="stop-color:#ff54d2;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop6257-5-4-6-4"
+         style="stop-color:#f62b68;stop-opacity:1"
+         offset="0.32368398" />
+      <stop
+         id="stop6255-6-7-9-7"
+         style="stop-color:#ff0105;stop-opacity:1"
+         offset="0.56140333" />
+      <stop
+         id="stop6092-0-22-2-1"
+         style="stop-color:#ff54d2;stop-opacity:0.47826087"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4316-4-0-7-5-1">
+      <stop
+         id="stop4318-4-5-3-2-3"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4320-2-9-4-1-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.33799788" />
+      <stop
+         id="stop4322-4-1-3-4-1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.61996669" />
+      <stop
+         id="stop4324-4-8-66-2-4"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4278-3-5-5-9">
+      <stop
+         id="stop4280-6-90-6-3"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop4286-1-9-5-7"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0.5" />
+      <stop
+         id="stop4282-24-4-0-5"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-691-4-22-1-2">
+      <stop
+         id="stop7191-4-6-8-8"
+         style="stop-color:#612f91;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7197-2-8-6-5"
+         style="stop-color:#1a4aa2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="7.0776"
+       y1="3.0816"
+       x2="7.0776"
+       y2="45.368999"
+       id="linearGradient3087-408-5-3-7-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22110724,0,0,0.22110728,6.6934256,6.693263)">
+      <stop
+         id="stop7201-5-71-3-5"
+         style="stop-color:#170418;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7203-2-8-8-5"
+         style="stop-color:#50386b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6042-1-7-8-8">
+      <stop
+         id="stop6044-9-6-3-6"
+         style="stop-color:#07132d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6046-9-5-1-2"
+         style="stop-color:#425479;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4507-6-5-9-8">
+      <stop
+         id="stop4509-3-8-8-5"
+         style="stop-color:#2d3955;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5959-4-45-4-7"
+         style="stop-color:#2b3853;stop-opacity:1"
+         offset="0.72468865" />
+      <stop
+         id="stop5961-1-7-2-5"
+         style="stop-color:#192640;stop-opacity:1"
+         offset="0.75" />
+      <stop
+         id="stop4511-1-0-8-9"
+         style="stop-color:#08142e;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4316-5-3-5-6">
+      <stop
+         id="stop4318-1-6-2-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4320-9-8-9-7"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.33799788" />
+      <stop
+         id="stop4322-42-31-5-1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.61996669" />
+      <stop
+         id="stop4324-9-9-3-4"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4220-7-2-0-5">
+      <stop
+         id="stop4222-7-5-5-4"
+         style="stop-color:#7a8498;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4224-0-5-2-0"
+         style="stop-color:#34405c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4806-2-9-2">
+      <stop
+         id="stop4808-4-6-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4810-0-9-3"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.42447853" />
+      <stop
+         id="stop4812-8-7-9"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.82089913" />
+      <stop
+         id="stop4814-0-7-4"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="23.896"
+       cy="3.99"
+       r="20.396999"
+       id="radialGradient3093-0-3-6-6-0-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.2316483,-1.625754,0,18.486966,-28.721977)">
+      <stop
+         id="stop3244-9-33-7-0-9-5-0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-3-5-0-8-5-0-0"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-1-7-8-8-1-0-6"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-9-3-0-5-1-2-1"
+         style="stop-color:#89898b;stop-opacity:1"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4316-5-3-5-6"
+       id="linearGradient3257"
+       gradientUnits="userSpaceOnUse"
+       x1="92.696327"
+       y1="16.554602"
+       x2="92.696327"
+       y2="48.983677"
+       gradientTransform="matrix(0.28074864,0,0,0.28074736,-17.85294,-1.1436724)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4806-2-9-2"
+       id="linearGradient3268"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53899369,0,0,0.53899369,-30.902467,-7.020086)"
+       x1="71.204407"
+       y1="15.369057"
+       x2="71.204407"
+       y2="40.495617" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       id="radialGradient3271"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.66138163,-0.49830779,0,9.9883774,-14.785278)"
+       cx="24.401789"
+       cy="3.9899998"
+       fx="24.401789"
+       fy="3.9899998"
+       r="20.396999" />
+    <radialGradient
+       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3032"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3030"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3028"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       y2="43"
+       x2="23.99999"
+       y1="5.5641499"
+       x1="23.99999"
+       gradientTransform="matrix(0.47495484,0.10529495,-0.08189607,0.3694093,2.5610785,0.107101)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4206"
+       xlink:href="#linearGradient3977-7-61"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(0.52998804,0.11749552,-0.0705431,0.31819937,1.0760283,0.555165)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4204"
+       xlink:href="#linearGradient3600-9-51"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="52.887863"
+       x2="-76.844345"
+       y1="6.6805849"
+       x1="-76.834877"
+       gradientTransform="matrix(0.47467232,0.10551084,-0.07512695,0.33933623,60.451903,11.735858)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4202"
+       xlink:href="#linearGradient4623-7-15"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4623-7-15">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.27058825"
+         id="stop4625-3-7" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.368"
+         id="stop4627-1-42" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-9-51">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3977-7-61">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-6-49" />
+      <stop
+         offset="0.03626217"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-3-78" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-8-86" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-2-07" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3825-5-8-9">
+      <stop
+         offset="0"
+         style="stop-color:#e89c42;stop-opacity:1"
+         id="stop3827-2-3-55" />
+      <stop
+         offset="1"
+         style="stop-color:#faca67;stop-opacity:1"
+         id="stop3829-5-0-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3871-6-7">
+      <stop
+         offset="0"
+         style="stop-color:#0b85e9;stop-opacity:1"
+         id="stop3873-3-2" />
+      <stop
+         offset="1"
+         style="stop-color:#69d1ef;stop-opacity:1"
+         id="stop3875-4-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4470-86-9">
+      <stop
+         offset="0"
+         style="stop-color:#ec4502;stop-opacity:1"
+         id="stop4472-0-4" />
+      <stop
+         offset="1"
+         style="stop-color:#fe7617;stop-opacity:1"
+         id="stop4474-9-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4574-39-1">
+      <stop
+         offset="0"
+         style="stop-color:#7a0f01;stop-opacity:1"
+         id="stop4576-75-8" />
+      <stop
+         offset="1"
+         style="stop-color:#d31807;stop-opacity:1"
+         id="stop4578-96-3" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0,1.2316483,-1.625754,0,18.486966,-28.721977)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3093-0-3-6-6-0-8-0"
+       r="20.396999"
+       cy="3.99"
+       cx="23.896">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3244-9-33-7-0-9-5-0-4" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#dddddd;stop-opacity:1"
+         id="stop3246-3-5-0-8-5-0-0-8" />
+      <stop
+         offset="0.66093999"
+         style="stop-color:#abacae;stop-opacity:1"
+         id="stop3248-1-7-8-8-1-0-6-0" />
+      <stop
+         offset="1"
+         style="stop-color:#89898b;stop-opacity:1"
+         id="stop3250-9-3-0-5-1-2-1-8" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient4806-2-9-2-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4808-4-6-7-5" />
+      <stop
+         offset="0.42447853"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4810-0-9-3-3" />
+      <stop
+         offset="0.82089913"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4812-8-7-9-8" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4814-0-7-4-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4220-7-2-0-5-4">
+      <stop
+         offset="0"
+         style="stop-color:#7a8498;stop-opacity:1"
+         id="stop4222-7-5-5-4-9" />
+      <stop
+         offset="1"
+         style="stop-color:#34405c;stop-opacity:1"
+         id="stop4224-0-5-2-0-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4316-5-3-5-6-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4318-1-6-2-7-4" />
+      <stop
+         offset="0.33799788"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4320-9-8-9-7-3" />
+      <stop
+         offset="0.61996669"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4322-42-31-5-1-4" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4324-9-9-3-4-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4507-6-5-9-8-4">
+      <stop
+         offset="0"
+         style="stop-color:#2d3955;stop-opacity:1"
+         id="stop4509-3-8-8-5-0" />
+      <stop
+         offset="0.72468865"
+         style="stop-color:#2b3853;stop-opacity:1"
+         id="stop5959-4-45-4-7-6" />
+      <stop
+         offset="0.75"
+         style="stop-color:#192640;stop-opacity:1"
+         id="stop5961-1-7-2-5-8" />
+      <stop
+         offset="1"
+         style="stop-color:#08142e;stop-opacity:1"
+         id="stop4511-1-0-8-9-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.22110724,0,0,0.22110728,6.6934256,6.693263)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3087-408-5-3-7-9-7"
+       y2="45.368999"
+       x2="7.0776"
+       y1="3.0816"
+       x1="7.0776">
+      <stop
+         offset="0"
+         style="stop-color:#170418;stop-opacity:1"
+         id="stop7201-5-71-3-5-1" />
+      <stop
+         offset="1"
+         style="stop-color:#50386b;stop-opacity:1"
+         id="stop7203-2-8-8-5-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-691-4-22-1-2-2">
+      <stop
+         offset="0"
+         style="stop-color:#612f91;stop-opacity:1"
+         id="stop7191-4-6-8-8-0" />
+      <stop
+         offset="1"
+         style="stop-color:#1a4aa2;stop-opacity:1"
+         id="stop7197-2-8-6-5-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4278-3-5-5-9-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop4280-6-90-6-3-6" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop4286-1-9-5-7-4" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop4282-24-4-0-5-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4316-4-0-7-5-1-0">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4318-4-5-3-2-3-5" />
+      <stop
+         offset="0.33799788"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4320-2-9-4-1-5-8" />
+      <stop
+         offset="0.61996669"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4322-4-1-3-4-1-9" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4324-4-8-66-2-4-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6088-74-4-8-8-9">
+      <stop
+         offset="0"
+         style="stop-color:#ff54d2;stop-opacity:0"
+         id="stop6090-5-66-7-7-6" />
+      <stop
+         offset="0.32368398"
+         style="stop-color:#f62b68;stop-opacity:1"
+         id="stop6257-5-4-6-4-1" />
+      <stop
+         offset="0.56140333"
+         style="stop-color:#ff0105;stop-opacity:1"
+         id="stop6255-6-7-9-7-3" />
+      <stop
+         offset="1"
+         style="stop-color:#ff54d2;stop-opacity:0.47826087"
+         id="stop6092-0-22-2-1-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4316-4-6-6-4-5-1-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4318-4-4-6-5-3-0-9" />
+      <stop
+         offset="0.33799788"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4320-2-2-6-59-35-1-8" />
+      <stop
+         offset="0.61996669"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4322-4-5-5-0-1-8-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4324-4-1-5-5-42-0-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3990-3-1-7-0-9-2">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3992-0-0-1-0-0-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3994-2-1-8-6-6-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6191-9-9-5-0-2">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6193-8-1-3-2-2" />
+      <stop
+         offset="0.40531859"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6197-8-8-7-1-0" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.47826087"
+         id="stop6195-9-3-6-0-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6191-7-9-4-9-2-6">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6193-7-3-6-0-5-3" />
+      <stop
+         offset="0.40531859"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6197-2-2-0-4-9-2" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.47826087"
+         id="stop6195-2-1-9-1-9-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6191-8-3-4-5-4-5">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6193-75-7-6-4-2-5" />
+      <stop
+         offset="0.40531859"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6197-3-4-1-4-8-2" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.47826087"
+         id="stop6195-7-2-5-7-8-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6088-6-1-0-06-8-0">
+      <stop
+         offset="0"
+         style="stop-color:#ff54d2;stop-opacity:0"
+         id="stop6090-2-0-4-9-4-0" />
+      <stop
+         offset="0.32368398"
+         style="stop-color:#ff54d2;stop-opacity:0"
+         id="stop6257-4-6-1-76-0-8" />
+      <stop
+         offset="0.56140333"
+         style="stop-color:#ff54d2;stop-opacity:0.2521739"
+         id="stop6255-3-6-7-23-8-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ff54d2;stop-opacity:0.47826087"
+         id="stop6092-9-6-8-9-2-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6303-4-8-5-0-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop6305-33-3-3-7-0" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6307-9-3-4-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6303-3-2-1-4-9-1">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop6305-3-0-9-0-0-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6307-1-0-1-2-1-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6303-33-0-2-0-0-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop6305-1-0-2-0-2-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6307-5-0-6-1-8-5" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient6303-33-0-2-0-0-7"
+       id="radialGradient5697-4"
+       fy="39.708927"
+       fx="36.49107"
+       r="3.1589286"
+       cy="39.708927"
+       cx="36.49107" />
+    <linearGradient
+       id="linearGradient6413-0-0-0-9">
+      <stop
+         offset="0"
+         style="stop-color:#feffff;stop-opacity:1"
+         id="stop6415-1-7-3-8" />
+      <stop
+         offset="1"
+         style="stop-color:#fe70ca;stop-opacity:1"
+         id="stop6417-4-9-2-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6455-7-3-3-2">
+      <stop
+         offset="0"
+         style="stop-color:#fbac9b;stop-opacity:1"
+         id="stop6457-5-1-10-5" />
+      <stop
+         offset="1"
+         style="stop-color:#fcfafc;stop-opacity:1"
+         id="stop6459-8-9-7-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6455-7-3-3-2"
+       id="linearGradient4789"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12398751,0,0,0.12970493,-13.687078,3.0035827)"
+       x1="38.851257"
+       y1="41.608219"
+       x2="34.130882"
+       y2="37.809635" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6413-0-0-0-9"
+       id="linearGradient4792"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17728269,0,0,0.18545771,-15.949877,0.4570362)"
+       x1="38.851257"
+       y1="41.608219"
+       x2="34.130882"
+       y2="37.809635" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6303-33-0-2-0-0-7"
+       id="radialGradient4795"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17728269,0,0,0.18545771,-14.462648,1.3571952)"
+       cx="36.49107"
+       cy="39.708927"
+       fx="36.49107"
+       fy="39.708927"
+       r="3.1589286" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6303-3-2-1-4-9-1"
+       id="radialGradient4798"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62147768,-0.35880864,0.20415069,0.35359772,-40.734448,5.6628847)"
+       cx="36.49107"
+       cy="39.708927"
+       fx="36.49107"
+       fy="39.708927"
+       r="3.1589286" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6303-4-8-5-0-4"
+       id="radialGradient4801"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.77231662,-0.44589514,0.25370014,0.43941951,-44.371628,10.048644)"
+       cx="36.49107"
+       cy="39.708927"
+       fx="36.49107"
+       fy="39.708927"
+       r="3.1589286" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6088-6-1-0-06-8-0"
+       id="radialGradient4804"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.49390196,-0.49389966,0.49390196,-0.49389966,-7.313881,39.867823)"
+       cx="32.372566"
+       cy="31.405056"
+       fx="32.372566"
+       fy="31.405056"
+       r="3.857446" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6191-8-3-4-5-4-5"
+       id="radialGradient4807"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.42281461,0.58712428,-0.56680474,0.40817779,-3.679261,-22.814809)"
+       cx="32.372566"
+       cy="31.405056"
+       fx="32.372566"
+       fy="31.405056"
+       r="3.857446" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6191-7-9-4-9-2-6"
+       id="radialGradient4810"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.72352295,-0.69848286,-2.9134813e-8,14.185521,-15.206288)"
+       cx="32.372566"
+       cy="31.405056"
+       fx="32.372566"
+       fy="31.405056"
+       r="3.857446" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4316-4-6-6-4-5-1-4"
+       id="linearGradient4813"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03119429,0,0,0.03119429,-10.807635,8.5077947)"
+       x1="92.696327"
+       y1="16.554602"
+       x2="92.696327"
+       y2="48.983677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4316-4-0-7-5-1-0"
+       id="linearGradient4817"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09358287,0,0,-0.09358287,-16.552733,12.571965)"
+       x1="92.696327"
+       y1="16.554602"
+       x2="92.696327"
+       y2="48.983677" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4278-3-5-5-9-6"
+       id="radialGradient4820"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.10126127,-1.5099331e-8,1.418703e-8,0.09514217,-17.655502,0.4110469)"
+       cx="95.838364"
+       cy="95.388451"
+       fx="95.838364"
+       fy="95.388451"
+       r="9.4981718" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-691-4-22-1-2-2"
+       id="radialGradient4823"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.05844326,-0.07714375,0,-7.627281,7.5915107)"
+       cx="23.896"
+       cy="3.99"
+       r="20.396999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3087-408-5-3-7-9-7"
+       id="linearGradient4825"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0244874,0,0,0.0244875,-8.52279,8.9361187)"
+       x1="7.0776"
+       y1="3.0816"
+       x2="7.0776"
+       y2="45.368999" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4507-6-5-9-8-4"
+       id="radialGradient4829"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.37957958,-0.37988951,0,-1.686753,-28.071387)"
+       cx="91.349998"
+       cy="16.447752"
+       fx="91.349998"
+       fy="16.447752"
+       r="15.639286" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4220-7-2-0-5-4"
+       id="linearGradient4832"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18716564,0,0,0.18716564,-25.17037,3.4293157)"
+       x1="91.566116"
+       y1="16.542858"
+       x2="91.566116"
+       y2="48.631081" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4316-5-3-5-6-4"
+       id="linearGradient4835"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18716576,0,0,0.18716483,-25.17038,3.4276257)"
+       x1="92.696327"
+       y1="16.554602"
+       x2="92.696327"
+       y2="48.983677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4806-2-9-2-7"
+       id="linearGradient4838"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.37314954,0,0,0.37314954,-34.867569,-0.874688)"
+       x1="71.204407"
+       y1="15.369057"
+       x2="71.204407"
+       y2="40.495617" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#radialGradient3093-0-3-6-6-0-8-0"
+       id="radialGradient4842"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.7045177,-0.92995165,0,-4.224487,-12.41507)"
+       cx="23.896"
+       cy="3.99"
+       fx="23.896"
+       fy="3.99"
+       r="20.396999" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6191-9-9-5-0-2"
+       id="radialGradient4846"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.69887275,0.18726152,-0.18078067,0.67467948,-24.741885,-18.238392)"
+       cx="32.372566"
+       cy="31.405056"
+       fx="32.372566"
+       fy="31.405056"
+       r="3.857446" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3990-3-1-7-0-9-2"
+       id="linearGradient4849"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05404846,0,0,0.04053616,-11.408361,5.9437627)"
+       x1="68.313301"
+       y1="52.925316"
+       x2="68.313301"
+       y2="65.922028" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6088-74-4-8-8-9"
+       id="radialGradient4852"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.69848286,0,0,-0.69847961,14.823229,30.954427)"
+       cx="32.372566"
+       cy="31.405056"
+       fx="32.372566"
+       fy="31.405056"
+       r="3.857446" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4574-39-1"
+       id="linearGradient4855"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07502968,0,0,0.07558974,-5.065318,2.381828)"
+       x1="-184.92441"
+       y1="113.97943"
+       x2="-175.25337"
+       y2="88.801025" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4470-86-9"
+       id="linearGradient4859"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07511055,0.00586778,-0.00619394,0.07150456,-1.930196,4.0705937)"
+       x1="-211.28862"
+       y1="88.750069"
+       x2="-208.49672"
+       y2="75.190559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3871-6-7"
+       id="linearGradient4867"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11183314,0,0,0.11948791,0.116521,2.1373528)"
+       x1="-107.45584"
+       y1="-37.385227"
+       x2="-107.45584"
+       y2="38.561256" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825-5-8-9"
+       id="linearGradient4872"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11183314,0,0,0.11095306,0.116521,1.9574013)"
+       x1="-96.557358"
+       y1="110.92493"
+       x2="-96.557358"
+       y2="39.991924" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3977-7-61"
+       id="linearGradient4875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48648651,0,0,0.37837838,-26.110758,-3.057242)"
+       x1="23.99999"
+       y1="5.5641499"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient4878"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.54285589,0,0,0.3259251,-27.463628,-2.2983752)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4623-7-15"
+       id="linearGradient4881"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48625742,2.7191503e-4,9.9659804e-5,0.34755305,32.924746,-4.2340016)"
+       x1="-76.834877"
+       y1="6.6805849"
+       x2="-76.844345"
+       y2="52.887863" />
+    <linearGradient
+       id="linearGradient4316-5-3-5-6-4-5">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4318-1-6-2-7-4-4" />
+      <stop
+         offset="0.33799788"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4320-9-8-9-7-3-2" />
+      <stop
+         offset="0.61996669"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4322-42-31-5-1-4-4" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4324-9-9-3-4-2-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-7">
+      <stop
+         id="stop3750-8-9-6"
+         style="stop-color:#bebebe;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3752-3-2-2"
+         style="stop-color:#969696;stop-opacity:1;"
+         offset="0.26238" />
+      <stop
+         id="stop3754-7-2-00"
+         style="stop-color:#8e8e8e;stop-opacity:1;"
+         offset="0.704952" />
+      <stop
+         id="stop3756-9-3-69"
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="99.157013"
+       cy="186.17059"
+       r="62.769119"
+       fx="99.157013"
+       fy="186.17059"
+       id="radialGradient3043"
+       xlink:href="#linearGradient3820-7-2-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.37681,18.119145)" />
+    <linearGradient
+       id="linearGradient3820-7-2-2">
+      <stop
+         id="stop3822-2-6-36"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3864-8-7-6"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         offset="0.5" />
+      <stop
+         id="stop3824-1-2-4"
+         style="stop-color:#686868;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="15.645058"
+       cy="8.449769"
+       r="19.99999"
+       fx="-0.025213266"
+       fy="8.44977"
+       id="radialGradient3040"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-4.7487871e-8,0.78038851,-0.73523897,-5.3752024e-8,22.21268,1.6839966)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
+      <stop
+         id="stop3750-8-9"
+         style="stop-color:#8de53e;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3752-3-2"
+         style="stop-color:#95de55;stop-opacity:1;"
+         offset="0.26238" />
+      <stop
+         id="stop3754-7-2"
+         style="stop-color:#82de31;stop-opacity:1;"
+         offset="0.704952" />
+      <stop
+         id="stop3756-9-3"
+         style="stop-color:#60cc00;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3821">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g4447">
+    <g
+       id="g4410">
+      <path
+         inkscape:transform-center-y="12.115467"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3271);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+         id="path2555-7-2-5"
+         inkscape:connector-curvature="0"
+         d="m 7.9999999,0.99999865 c -3.8623577,0 -6.99999993,3.13764035 -6.99999993,7.00000085 0,3.8623615 3.13764223,7.0000015 6.99999993,7.0000015 3.8623581,0 7.0000061,-3.13764 7.0000001,-7.0000015 C 15,4.137639 11.862358,0.99999865 7.9999999,0.99999865 Z" />
+      <path
+         style="opacity:0.3;color:#000000;fill:none;stroke:url(#linearGradient3268);stroke-width:0.99999982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="path4176-3"
+         inkscape:connector-curvature="0"
+         d="M 14.5,8.0000001 C 14.5,11.589853 11.589854,14.5 7.9999934,14.5 4.4101457,14.5 1.5,11.589853 1.5,8.0000001 1.5,4.4101466 4.4101457,1.5 7.9999934,1.5 11.589854,1.5 14.5,4.4101466 14.5,8.0000001 z" />
+      <path
+         style="opacity:0.4;color:#000000;fill:none;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path3871-0"
+         inkscape:connector-curvature="0"
+         d="m 7.9998579,0.500281 c -4.138162,0 -7.49985796,3.361693 -7.49985796,7.499859 0,4.138166 3.36169596,7.49986 7.49985796,7.49986 4.1381621,0 7.4998651,-3.361694 7.4998581,-7.49986 0,-4.138166 -3.361696,-7.499859 -7.4998581,-7.499859 z" />
+    </g>
+    <g
+       transform="matrix(0.25348362,0,0,0.25348362,-0.12724226,-0.17156588)"
+       id="g3882">
+      <g
+         id="g3869">
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="rect3883"
+           d="m 17.298088,40.902181 c 0.5927,-2.211986 2.511307,-2.908051 4.505133,-2.908051 3.046229,0 6.075666,0.293311 8.946667,1.062595 2.871,0.769281 5.750306,2.092963 8.279337,3.553099 1.726704,0.996913 2.991573,2.740627 2.412776,4.900726 -0.44672,1.667187 -2.298784,2.114913 -4.025488,1.117998 -2.504852,-1.446176 -5.408337,-2.783817 -8.279338,-3.553099 -2.871001,-0.769284 -5.985761,-1.062595 -8.946666,-1.062595 -1.993826,0 -3.339143,-1.443486 -2.892421,-3.110673 z"
+           style="opacity:0.9;fill:#1a1a1a;fill-opacity:1;stroke:none" />
+        <path
+           style="opacity:0.9;fill:#1a1a1a;fill-opacity:1;stroke:none"
+           d="m 14.48274,30.10568 c 0.592699,-2.211984 2.511306,-2.90805 4.505132,-2.908051 3.046229,1e-6 8.414615,0.369513 14.734347,2.06288 5.80609,1.555737 10.715029,3.816484 13.24406,5.276623 1.726704,0.996912 2.991575,2.740624 2.412777,4.900724 -0.446721,1.667187 -2.298785,2.114913 -4.025488,1.118 C 42.848715,39.10968 38.062352,36.874294 32.109506,35.279234 26.523547,33.78248 20.336065,33.216355 17.37516,33.216355 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110675 z"
+           id="path3895"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="path3897"
+           d="m 12.346123,19.69258 c 0.592699,-2.211986 2.511306,-2.908051 4.505132,-2.908051 3.046229,0 11.800505,0.647594 19.147517,2.61622 9.3282,2.499482 14.192548,5.220155 16.72158,6.680294 1.726704,0.996912 2.991572,2.740624 2.412776,4.900724 -0.446721,1.667186 -2.298785,2.114913 -4.02549,1.117999 C 48.602789,30.653589 40.045396,26.935888 34.38606,25.419475 27.99295,23.706446 18.199449,22.803253 15.238543,22.803253 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110673 z"
+           style="opacity:0.9;fill:#1a1a1a;fill-opacity:1;stroke:none" />
+      </g>
+      <g
+         id="g3874"
+         style="opacity:0.2;fill:#ffffff"
+         transform="translate(0,1.4142136)">
+        <path
+           style="opacity:0.9;fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 17.298088,40.902181 c 0.5927,-2.211986 2.511307,-2.908051 4.505133,-2.908051 3.046229,0 6.075666,0.293311 8.946667,1.062595 2.871,0.769281 5.750306,2.092963 8.279337,3.553099 1.726704,0.996913 2.991573,2.740627 2.412776,4.900726 -0.44672,1.667187 -2.298784,2.114913 -4.025488,1.117998 -2.504852,-1.446176 -5.408337,-2.783817 -8.279338,-3.553099 -2.871001,-0.769284 -5.985761,-1.062595 -8.946666,-1.062595 -1.993826,0 -3.339143,-1.443486 -2.892421,-3.110673 z"
+           id="path3876"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="path3878"
+           d="m 14.48274,30.10568 c 0.592699,-2.211984 2.511306,-2.90805 4.505132,-2.908051 3.046229,1e-6 8.414615,0.369513 14.734347,2.06288 5.80609,1.555737 10.715029,3.816484 13.24406,5.276623 1.726704,0.996912 2.991575,2.740624 2.412777,4.900724 -0.446721,1.667187 -2.298785,2.114913 -4.025488,1.118 C 42.848715,39.10968 38.062352,36.874294 32.109506,35.279234 26.523547,33.78248 20.336065,33.216355 17.37516,33.216355 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110675 z"
+           style="opacity:0.9;fill:#ffffff;fill-opacity:1;stroke:none" />
+        <path
+           style="opacity:0.9;fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 12.346123,19.69258 c 0.592699,-2.211986 2.511306,-2.908051 4.505132,-2.908051 3.046229,0 11.800505,0.647594 19.147517,2.61622 9.3282,2.499482 14.192548,5.220155 16.72158,6.680294 1.726704,0.996912 2.991572,2.740624 2.412776,4.900724 -0.446721,1.667186 -2.298785,2.114913 -4.02549,1.117999 C 48.602789,30.653589 40.045396,26.935888 34.38606,25.419475 27.99295,23.706446 18.199449,22.803253 15.238543,22.803253 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110673 z"
+           id="path3880"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/elementaryPlus/apps/24/spotify-client.svg
+++ b/elementaryPlus/apps/24/spotify-client.svg
@@ -1,0 +1,953 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="24"
+   height="24"
+   id="svg2890"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="circleicon24.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1025"
+     id="namedview107"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="-288.28292"
+     inkscape:cy="107.99905"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2890" />
+  <metadata
+     id="metadata38397">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2892">
+    <linearGradient
+       id="linearGradient4222">
+      <stop
+         id="stop4224"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4226"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="13.471772"
+       y1="25.410501"
+       x2="57.726395"
+       y2="25.410501"
+       id="linearGradient3134"
+       xlink:href="#linearGradient4222"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.3704967,-0.3617496,0,-4.130239,3.3844037)" />
+    <linearGradient
+       id="linearGradient2264">
+      <stop
+         id="stop2266"
+         style="stop-color:#d7e866;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2268"
+         style="stop-color:#8cab2a;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="28.314739"
+       y1="20.709501"
+       x2="0.81572169"
+       y2="20.709501"
+       id="linearGradient3132"
+       xlink:href="#linearGradient2264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.319447,-0.313352,0,-6.152273,19.802328)" />
+    <linearGradient
+       id="linearGradient23419">
+      <stop
+         id="stop23421"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop23423"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="23.334524"
+       cy="41.63604"
+       r="22.627417"
+       fx="23.334524"
+       fy="41.63604"
+       id="radialGradient2888"
+       xlink:href="#linearGradient23419"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4861359,0,0,0.1546652,0.6562496,13.060353)" />
+    <linearGradient
+       id="linearGradient3772">
+      <stop
+         id="stop3774"
+         style="stop-color:#b4b4b4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3776"
+         style="stop-color:#969696;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-21.915663"
+       y1="3"
+       x2="-21.915663"
+       y2="45.032898"
+       id="linearGradient2885"
+       xlink:href="#linearGradient3772"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5121951,0,0,0.5121951,25.452835,-0.2926833)" />
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient3263"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3265"
+         style="stop-color:#dddddd;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3267"
+         style="stop-color:#c3c3c3;stop-opacity:1;"
+         offset="0.5" />
+      <stop
+         offset="0.75"
+         style="stop-color:#a4a4a4;stop-opacity:1;"
+         id="stop3908" />
+      <stop
+         id="stop3269"
+         style="stop-color:#979797;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient2883"
+       xlink:href="#linearGradient3263"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.6000053,-0.6000053,0,25.860125,-2.4001307)" />
+    <linearGradient
+       id="linearGradient3428">
+      <stop
+         id="stop3430"
+         style="stop-color:#aaaaaa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3432"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="21.448364"
+       y1="15.5"
+       x2="21.448364"
+       y2="32.509201"
+       id="linearGradient2879"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4374999,0,0,0.4374999,1.5000004,1.5000003)" />
+    <linearGradient
+       x1="18.775953"
+       y1="4.0378027"
+       x2="18.203465"
+       y2="45.962208"
+       id="linearGradient2876"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2272999,0,0,0.2272999,6.4659273,6.3175018)" />
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient2488"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient2486"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient2484"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient2482"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient2480"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient6036">
+      <stop
+         id="stop6038"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6040"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.50172"
+       y1="3.6100161"
+       x2="48.798885"
+       y2="54.698483"
+       id="linearGradient2867"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4820056,0,0,0.4820056,0.2646087,-0.05013717)" />
+    <linearGradient
+       id="linearGradient3519">
+      <stop
+         id="stop3521"
+         style="stop-color:#fcd9cd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3523"
+         style="stop-color:#fcd9cd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient2500"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3511">
+      <stop
+         id="stop3513"
+         style="stop-color:#ebeec7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3515"
+         style="stop-color:#ebeec7;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient2498"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3503">
+      <stop
+         id="stop3505"
+         style="stop-color:#c4ebdd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3507"
+         style="stop-color:#c4ebdd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient2496"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3495">
+      <stop
+         id="stop3497"
+         style="stop-color:#c1cbe4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3499"
+         style="stop-color:#c1cbe4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient2494"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3487">
+      <stop
+         id="stop3489"
+         style="stop-color:#e6cde2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3491"
+         style="stop-color:#e6cde2;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient2492"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3121"
+       xlink:href="#linearGradient3707-319-631-407-324-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.38465107,0,0,0.38465106,-1.231625,-1.2316257)" />
+    <radialGradient
+       cx="5.7800279"
+       cy="8.4497671"
+       r="19.99999"
+       fx="5.7800279"
+       fy="8.4497671"
+       id="radialGradient3119"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.89892574,-0.95095622,-1.6561642e-8,16.035401,-6.0146846)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-3-8">
+      <stop
+         id="stop3760-7-3"
+         style="stop-color:#185f9a;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3762-8-4"
+         style="stop-color:#599ec9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
+      <stop
+         id="stop3750-8-9"
+         style="stop-color:#90dbec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-2"
+         style="stop-color:#55c1ec;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-7-2"
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-9-3"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         id="stop4013"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4015"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.507761" />
+      <stop
+         id="stop4017"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
+      <stop
+         id="stop4019"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794"
+       id="linearGradient3071"
+       xlink:href="#linearGradient4011"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35135136,0,0,0.35135136,-17.203671,-0.90930013)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-3-8-2">
+      <stop
+         id="stop3760-7-3-6"
+         style="stop-color:#185f9a;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3762-8-4-8"
+         style="stop-color:#599ec9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="7.8555918"
+       y1="15.85593"
+       x2="7.8555918"
+       y2="-0.12225635"
+       id="linearGradient4037-4"
+       xlink:href="#linearGradient3707-319-631-407-324-3-8-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1.155436)" />
+    <linearGradient
+       x1="7.8555918"
+       y1="15.85593"
+       x2="7.8555918"
+       y2="-0.12225635"
+       id="linearGradient3115"
+       xlink:href="#linearGradient3707-319-631-407-324-3-8-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(9,10.155436)" />
+    <linearGradient
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794"
+       id="linearGradient3118"
+       xlink:href="#linearGradient4011"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.29729731,0,0,0.29729731,-4.3261833,9.4613611)" />
+    <radialGradient
+       cx="5.7800279"
+       cy="8.4497671"
+       r="19.99999"
+       fx="5.7800279"
+       fy="8.4497671"
+       id="radialGradient3121"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.77906898,-0.82416206,-1.4353423e-8,23.964014,4.8539399)" />
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3123"
+       xlink:href="#linearGradient3707-319-631-407-324-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33336426,0,0,0.33336425,8.9992583,8.9992576)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient23419"
+       id="radialGradient3084"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4861359,0,0,0.1546652,0.6562496,13.060353)"
+       cx="23.334524"
+       cy="41.63604"
+       fx="23.334524"
+       fy="41.63604"
+       r="22.627417" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3263"
+       id="linearGradient3086"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.6000053,-0.6000053,0,25.860125,-2.4001307)"
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3772"
+       id="linearGradient3088"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5121951,0,0,0.5121951,25.452835,-0.2926833)"
+       x1="-21.915663"
+       y1="3"
+       x2="-21.915663"
+       y2="45.032898" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3428"
+       id="linearGradient3090"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4374999,0,0,0.4374999,1.5000004,1.5000003)"
+       x1="21.448364"
+       y1="15.5"
+       x2="21.448364"
+       y2="32.509201" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036"
+       id="linearGradient3092"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2272999,0,0,0.2272999,6.4659273,6.3175018)"
+       x1="18.775953"
+       y1="4.0378027"
+       x2="18.203465"
+       y2="45.962208" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3487"
+       id="linearGradient3094"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3495"
+       id="linearGradient3096"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503"
+       id="linearGradient3098"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3511"
+       id="linearGradient3100"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3519"
+       id="linearGradient3102"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036"
+       id="linearGradient3104"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4820056,0,0,0.4820056,0.2646087,-0.05013717)"
+       x1="10.50172"
+       y1="3.6100161"
+       x2="48.798885"
+       y2="54.698483" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3487"
+       id="linearGradient3106"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3511"
+       id="linearGradient3108"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3519"
+       id="linearGradient3110"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036"
+       id="linearGradient3117"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4820056,0,0,0.4820056,0.2646087,-0.05013717)"
+       x1="10.50172"
+       y1="3.6100161"
+       x2="48.798885"
+       y2="54.698483" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036"
+       id="linearGradient3126"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2272999,0,0,0.2272999,6.4659273,6.3175018)"
+       x1="18.775953"
+       y1="4.0378027"
+       x2="18.203465"
+       y2="45.962208" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3428"
+       id="linearGradient3129"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4374999,0,0,0.4374999,1.5000004,1.5000003)"
+       x1="21.448364"
+       y1="15.5"
+       x2="21.448364"
+       y2="32.509201" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3263"
+       id="linearGradient3133"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.6000053,-0.6000053,0,25.860125,-2.4001307)"
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient23419"
+       id="radialGradient3138"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4861359,0,0,0.1546652,0.6562496,13.060353)"
+       cx="23.334524"
+       cy="41.63604"
+       fx="23.334524"
+       fy="41.63604"
+       r="22.627417" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-7"
+       id="radialGradient3914"
+       cx="17.115078"
+       cy="1.3498945"
+       fx="17.115078"
+       fy="1.3498945"
+       r="10.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0549333e-8,0.9427021,-0.98120682,-1.0980221e-8,13.338331,-3.7266572)" />
+    <radialGradient
+       cx="99.157013"
+       cy="186.17059"
+       r="62.769119"
+       fx="99.157013"
+       fy="186.17059"
+       id="radialGradient3043"
+       xlink:href="#linearGradient3820-7-2-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.37681,18.119145)" />
+    <linearGradient
+       id="linearGradient3820-7-2-2">
+      <stop
+         id="stop3822-2-6-36"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3864-8-7-6"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         offset="0.5" />
+      <stop
+         id="stop3824-1-2-4"
+         style="stop-color:#686868;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="17.810656"
+       cy="9.0656729"
+       r="19.99999"
+       fx="2.1403866"
+       fy="9.0656738"
+       id="radialGradient3040"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.4387769e-8,0.56510892,-0.53241443,-3.8923879e-8,-14.626163,4.6332389)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-7">
+      <stop
+         id="stop3750-8-9-6"
+         style="stop-color:#bebebe;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3752-3-2-2"
+         style="stop-color:#969696;stop-opacity:1;"
+         offset="0.26238" />
+      <stop
+         id="stop3754-7-2-00"
+         style="stop-color:#8e8e8e;stop-opacity:1;"
+         offset="0.704952" />
+      <stop
+         id="stop3756-9-3-69"
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-9"
+       id="radialGradient3894"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.4387769e-8,0.56510892,-0.53241443,-3.8923879e-8,16.498837,1.6332388)"
+       cx="17.810656"
+       cy="9.0656729"
+       fx="2.1403866"
+       fy="9.0656738"
+       r="19.99999" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3820-7-2-2"
+       id="radialGradient3897"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17524541,0,0,0.05575992,33.145159,15.839165)"
+       cx="99.157013"
+       cy="186.17059"
+       fx="99.157013"
+       fy="186.17059"
+       r="62.769119" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036"
+       id="linearGradient3900"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4820056,0,0,0.4820056,0.2646087,-0.05013717)"
+       x1="10.50172"
+       y1="3.6100161"
+       x2="48.798885"
+       y2="54.698483" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient23419"
+       id="radialGradient3904"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4861359,0,0,0.1546652,0.6562496,13.060353)"
+       cx="23.334524"
+       cy="41.63604"
+       fx="23.334524"
+       fy="41.63604"
+       r="22.627417" />
+    <radialGradient
+       cx="99.157013"
+       cy="186.17059"
+       r="62.769119"
+       fx="99.157013"
+       fy="186.17059"
+       id="radialGradient3018"
+       xlink:href="#linearGradient3820-7-2-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27083381,0,0,0.08762273,-2.855072,25.187228)" />
+    <linearGradient
+       id="linearGradient3820-7-2-1">
+      <stop
+         id="stop3822-2-6-3"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3864-8-7-7"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         offset="0.5" />
+      <stop
+         id="stop3824-1-2-5"
+         style="stop-color:#686868;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="3.9722471"
+       cy="8.4497671"
+       r="19.99999"
+       fx="3.9722471"
+       fy="8.4497671"
+       id="radialGradient3015"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.4988347,-2.6434689,-6.8014435e-8,46.336814,-12.180468)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-9">
+      <stop
+         id="stop3750-8-9-2"
+         style="stop-color:#8de53e;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3752-3-2-1"
+         style="stop-color:#95de55;stop-opacity:1;"
+         offset="0.26238" />
+      <stop
+         id="stop3754-7-2-0"
+         style="stop-color:#82de31;stop-opacity:1;"
+         offset="0.704952" />
+      <stop
+         id="stop3756-9-3-4"
+         style="stop-color:#60cc00;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4011-5"
+       id="linearGradient3801"
+       x1="16.415949"
+       y1="-2.6000259"
+       x2="16.415949"
+       y2="37.600647"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4011-5">
+      <stop
+         id="stop4013-1"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4015-7"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.507761" />
+      <stop
+         id="stop4017-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
+      <stop
+         id="stop4019-7"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g3952">
+    <g
+       id="g3906">
+      <path
+         style="opacity:0.3;fill:url(#radialGradient3904);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible"
+         id="path23417"
+         inkscape:connector-curvature="0"
+         d="M 23,19.499999 C 23.000566,21.432943 18.075533,23 12,23 5.924467,23 0.9994335,21.432943 1,19.499999 0.9994335,17.567056 5.924467,16 12,16 c 6.075533,0 11.000566,1.567056 11,3.499999 z" />
+      <path
+         d="M 12,1.4999996 C 6.2064623,1.4999996 1.5000003,6.2064609 1.5000003,11.999999 1.5000003,17.793538 6.2064623,22.500002 12,22.5 17.793538,22.5 22.500007,17.793538 22.5,11.999999 22.5,6.2064609 17.793538,1.4999996 12,1.4999996 z"
+         inkscape:connector-curvature="0"
+         id="path2555-7-66"
+         style="color:#000000;fill:url(#radialGradient3894);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         style="opacity:0.4;fill:none;stroke:#000000;stroke-width:1.00000012;stroke-miterlimit:4;stroke-opacity:1"
+         id="path2781"
+         inkscape:connector-curvature="0"
+         d="M 22.5,12 C 22.5,6.1799465 17.820052,1.4999997 12,1.4999997 6.1799464,1.4999997 1.5000001,6.179947 1.5000001,12 1.499999,17.820053 6.1799469,22.5 12,22.5 c 5.820052,-1e-6 10.5,-4.679947 10.5,-10.5 z"
+         sodipodi:nodetypes="sssss" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3900);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1"
+         id="path3272"
+         inkscape:connector-curvature="0"
+         d="m 12,2.4574317 c -5.2893093,0 -9.542569,4.25326 -9.542569,9.5425683 0,5.28931 4.2532597,9.542568 9.542569,9.542568 5.28931,0 9.542569,-4.253258 9.542569,-9.542568 C 21.542569,6.7106917 17.28931,2.4574317 12,2.4574317 l 0,0 0,0 z" />
+    </g>
+    <g
+       transform="matrix(0.35,0,0,0.35,0.88196817,0.76938545)"
+       id="g3882">
+      <g
+         id="g3869">
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="rect3883"
+           d="m 17.298088,40.902181 c 0.5927,-2.211986 2.511307,-2.908051 4.505133,-2.908051 3.046229,0 6.075666,0.293311 8.946667,1.062595 2.871,0.769281 5.750306,2.092963 8.279337,3.553099 1.726704,0.996913 2.991573,2.740627 2.412776,4.900726 -0.44672,1.667187 -2.298784,2.114913 -4.025488,1.117998 -2.504852,-1.446176 -5.408337,-2.783817 -8.279338,-3.553099 -2.871001,-0.769284 -5.985761,-1.062595 -8.946666,-1.062595 -1.993826,0 -3.339143,-1.443486 -2.892421,-3.110673 z"
+           style="opacity:0.9;fill:#1a1a1a;fill-opacity:1;stroke:none" />
+        <path
+           style="opacity:0.9;fill:#1a1a1a;fill-opacity:1;stroke:none"
+           d="m 14.48274,30.10568 c 0.592699,-2.211984 2.511306,-2.90805 4.505132,-2.908051 3.046229,1e-6 8.414615,0.369513 14.734347,2.06288 5.80609,1.555737 10.715029,3.816484 13.24406,5.276623 1.726704,0.996912 2.991575,2.740624 2.412777,4.900724 -0.446721,1.667187 -2.298785,2.114913 -4.025488,1.118 C 42.848715,39.10968 38.062352,36.874294 32.109506,35.279234 26.523547,33.78248 20.336065,33.216355 17.37516,33.216355 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110675 z"
+           id="path3895"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="path3897"
+           d="m 12.346123,19.69258 c 0.592699,-2.211986 2.511306,-2.908051 4.505132,-2.908051 3.046229,0 11.800505,0.647594 19.147517,2.61622 9.3282,2.499482 14.192548,5.220155 16.72158,6.680294 1.726704,0.996912 2.991572,2.740624 2.412776,4.900724 -0.446721,1.667186 -2.298785,2.114913 -4.02549,1.117999 C 48.602789,30.653589 40.045396,26.935888 34.38606,25.419475 27.99295,23.706446 18.199449,22.803253 15.238543,22.803253 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110673 z"
+           style="opacity:0.9;fill:#1a1a1a;fill-opacity:1;stroke:none" />
+      </g>
+      <g
+         id="g3874"
+         style="opacity:0.2;fill:#ffffff"
+         transform="translate(0,1.4142136)">
+        <path
+           style="opacity:0.9;fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 17.298088,40.902181 c 0.5927,-2.211986 2.511307,-2.908051 4.505133,-2.908051 3.046229,0 6.075666,0.293311 8.946667,1.062595 2.871,0.769281 5.750306,2.092963 8.279337,3.553099 1.726704,0.996913 2.991573,2.740627 2.412776,4.900726 -0.44672,1.667187 -2.298784,2.114913 -4.025488,1.117998 -2.504852,-1.446176 -5.408337,-2.783817 -8.279338,-3.553099 -2.871001,-0.769284 -5.985761,-1.062595 -8.946666,-1.062595 -1.993826,0 -3.339143,-1.443486 -2.892421,-3.110673 z"
+           id="path3876"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="path3878"
+           d="m 14.48274,30.10568 c 0.592699,-2.211984 2.511306,-2.90805 4.505132,-2.908051 3.046229,1e-6 8.414615,0.369513 14.734347,2.06288 5.80609,1.555737 10.715029,3.816484 13.24406,5.276623 1.726704,0.996912 2.991575,2.740624 2.412777,4.900724 -0.446721,1.667187 -2.298785,2.114913 -4.025488,1.118 C 42.848715,39.10968 38.062352,36.874294 32.109506,35.279234 26.523547,33.78248 20.336065,33.216355 17.37516,33.216355 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110675 z"
+           style="opacity:0.9;fill:#ffffff;fill-opacity:1;stroke:none" />
+        <path
+           style="opacity:0.9;fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 12.346123,19.69258 c 0.592699,-2.211986 2.511306,-2.908051 4.505132,-2.908051 3.046229,0 11.800505,0.647594 19.147517,2.61622 9.3282,2.499482 14.192548,5.220155 16.72158,6.680294 1.726704,0.996912 2.991572,2.740624 2.412776,4.900724 -0.446721,1.667186 -2.298785,2.114913 -4.02549,1.117999 C 48.602789,30.653589 40.045396,26.935888 34.38606,25.419475 27.99295,23.706446 18.199449,22.803253 15.238543,22.803253 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110673 z"
+           id="path3880"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/elementaryPlus/apps/32/spotify-client.svg
+++ b/elementaryPlus/apps/32/spotify-client.svg
@@ -1,0 +1,487 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg4505"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="circleicon32.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1025"
+     id="namedview54"
+     showgrid="false"
+     inkscape:zoom="11.313708"
+     inkscape:cx="4.2556854"
+     inkscape:cy="20.51163"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4505" />
+  <defs
+     id="defs4507">
+    <linearGradient
+       x1="71.204407"
+       y1="15.369057"
+       x2="71.204407"
+       y2="40.495617"
+       id="linearGradient4456"
+       xlink:href="#linearGradient4806-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1022033,0,0,1.1022038,-111.2554,-14.715001)" />
+    <linearGradient
+       id="linearGradient4806-9">
+      <stop
+         id="stop4808-49"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4810-05"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.42447853" />
+      <stop
+         id="stop4812-6"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.82089913" />
+      <stop
+         id="stop4814-7"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="18.164446"
+       cy="8.449769"
+       r="19.99999"
+       fx="8.894803"
+       fy="8.5985041"
+       id="radialGradient3126-7-25-1"
+       xlink:href="#linearGradient3242-7-3-8-9-94"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.97674024,-0.9227132,-1.1278942e-8,-23.90585,-1.8504794)" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-9-94">
+      <stop
+         id="stop3244-5-8-5-3-7"
+         style="stop-color:#eef87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9-5-1-2-9"
+         style="stop-color:#cde34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7-2-0-84-9"
+         style="stop-color:#93b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8-2-8-3-2"
+         style="stop-color:#5a7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-1085.9586"
+       y1="539.40955"
+       x2="-474.68497"
+       y2="375.61926"
+       id="linearGradient3510"
+       xlink:href="#XMLID_2_-8-6-1-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04972374,0,0,0.04180683,10.91005,-2.4805984)" />
+    <radialGradient
+       cx="299.44821"
+       cy="-290.5918"
+       r="17.1528"
+       fx="297.44989"
+       fy="-289.9133"
+       id="XMLID_2_-8-6-1-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8232,0.2312,0.2703,-0.9626,-96.2274,-315.3433)">
+      <stop
+         id="stop228-2-7-9-0"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop230-7-5-7-7"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <radialGradient
+       cx="15.645058"
+       cy="8.449769"
+       r="19.99999"
+       fx="-12.360565"
+       fy="8.4497719"
+       id="radialGradient3126-9"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-4.7487871e-8,0.78038851,-0.73523897,-5.3752024e-8,-25.48997,1.6839966)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-7">
+      <stop
+         id="stop3750-8-9-6"
+         style="stop-color:#bebebe;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3752-3-2-2"
+         style="stop-color:#969696;stop-opacity:1;"
+         offset="0.26238" />
+      <stop
+         id="stop3754-7-2-00"
+         style="stop-color:#8e8e8e;stop-opacity:1;"
+         offset="0.704952" />
+      <stop
+         id="stop3756-9-3-69"
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3820-7-2-2">
+      <stop
+         id="stop3822-2-6-36"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3864-8-7-6"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         offset="0.5" />
+      <stop
+         id="stop3824-1-2-4"
+         style="stop-color:#686868;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="99.157013"
+       cy="186.17059"
+       r="62.769119"
+       fx="99.157013"
+       fy="186.17059"
+       id="radialGradient4503"
+       xlink:href="#linearGradient3820-7-2-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.1666667,0,155.14216)" />
+    <radialGradient
+       cx="99.157013"
+       cy="186.17059"
+       r="62.769119"
+       fx="99.157013"
+       fy="186.17059"
+       id="radialGradient4600"
+       xlink:href="#linearGradient3820-7-2-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.1666667,0,155.14216)" />
+    <radialGradient
+       cx="15.645058"
+       cy="8.449769"
+       r="19.99999"
+       fx="-12.360565"
+       fy="8.4497719"
+       id="radialGradient4602"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-4.7487871e-8,0.78038851,-0.73523897,-5.3752024e-8,-25.48997,1.6839966)" />
+    <linearGradient
+       x1="-1085.9586"
+       y1="539.40955"
+       x2="-474.68497"
+       y2="375.61926"
+       id="linearGradient4604"
+       xlink:href="#XMLID_2_-8-6-1-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04972374,0,0,0.04180683,10.91005,-2.4805984)" />
+    <radialGradient
+       cx="18.164446"
+       cy="8.449769"
+       r="19.99999"
+       fx="8.894803"
+       fy="8.5985041"
+       id="radialGradient4606"
+       xlink:href="#linearGradient3242-7-3-8-9-94"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.97674024,-0.9227132,-1.1278942e-8,-23.90585,-1.8504794)" />
+    <linearGradient
+       x1="71.204407"
+       y1="15.369057"
+       x2="71.204407"
+       y2="40.495617"
+       id="linearGradient4608"
+       xlink:href="#linearGradient4806-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1022033,0,0,1.1022038,-111.2554,-14.715001)" />
+    <linearGradient
+       x1="71.204407"
+       y1="15.369057"
+       x2="71.204407"
+       y2="40.495617"
+       id="linearGradient4611"
+       xlink:href="#linearGradient4806-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1022033,0,0,1.1022038,-63.55275,-14.715001)" />
+    <radialGradient
+       cx="18.164446"
+       cy="8.449769"
+       r="19.99999"
+       fx="8.894803"
+       fy="8.5985041"
+       id="radialGradient4615"
+       xlink:href="#linearGradient3242-7-3-8-9-94"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.97674024,-0.9227132,-1.1278942e-8,23.7968,-1.8504794)" />
+    <linearGradient
+       x1="-1085.9586"
+       y1="539.40955"
+       x2="-474.68497"
+       y2="375.61926"
+       id="linearGradient4618"
+       xlink:href="#XMLID_2_-8-6-1-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04972374,0,0,0.04180683,58.6127,-2.4805984)" />
+    <radialGradient
+       cx="15.645058"
+       cy="8.449769"
+       r="19.99999"
+       fx="-12.360565"
+       fy="8.4497719"
+       id="radialGradient4623"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-4.7487871e-8,0.78038851,-0.73523897,-5.3752024e-8,22.21268,1.6839966)" />
+    <linearGradient
+       x1="71.204407"
+       y1="15.369057"
+       x2="71.204407"
+       y2="40.495617"
+       id="linearGradient3028"
+       xlink:href="#linearGradient4806-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1022033,0,0,1.1022038,-63.55275,-14.715001)" />
+    <radialGradient
+       cx="18.164446"
+       cy="8.449769"
+       r="19.99999"
+       fx="8.894803"
+       fy="8.5985041"
+       id="radialGradient3032"
+       xlink:href="#linearGradient3242-7-3-8-9-94"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.97674024,-0.9227132,-1.1278942e-8,23.7968,-1.8504794)" />
+    <linearGradient
+       x1="-1085.9586"
+       y1="539.40955"
+       x2="-474.68497"
+       y2="375.61926"
+       id="linearGradient3035"
+       xlink:href="#XMLID_2_-8-6-1-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04972374,0,0,0.04180683,58.6127,-2.4805984)" />
+    <radialGradient
+       cx="15.645058"
+       cy="8.449769"
+       r="19.99999"
+       fx="-0.025213266"
+       fy="8.44977"
+       id="radialGradient3040"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-4.7487871e-8,0.78038851,-0.73523897,-5.3752024e-8,22.21268,1.6839966)" />
+    <radialGradient
+       cx="99.157013"
+       cy="186.17059"
+       r="62.769119"
+       fx="99.157013"
+       fy="186.17059"
+       id="radialGradient3043"
+       xlink:href="#linearGradient3820-7-2-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.37681,18.119145)" />
+    <radialGradient
+       cx="99.157013"
+       cy="186.17059"
+       r="62.769119"
+       fx="99.157013"
+       fy="186.17059"
+       id="radialGradient5015"
+       xlink:href="#linearGradient3820-7-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.1666667,0,155.14216)" />
+    <linearGradient
+       id="linearGradient3820-7-2">
+      <stop
+         id="stop3822-2-6"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3864-8-7"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         offset="0.5" />
+      <stop
+         id="stop3824-1-2"
+         style="stop-color:#686868;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="15.645058"
+       cy="8.449769"
+       r="19.99999"
+       fx="-0.22334664"
+       fy="8.44977"
+       id="radialGradient5007"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-9.6613255e-8,1.5876869,-1.495831,-1.0935756e-7,44.6396,2.8743392)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
+      <stop
+         id="stop3750-8-9"
+         style="stop-color:#8de53e;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3752-3-2"
+         style="stop-color:#95de55;stop-opacity:1;"
+         offset="0.26238" />
+      <stop
+         id="stop3754-7-2"
+         style="stop-color:#82de31;stop-opacity:1;"
+         offset="0.704952" />
+      <stop
+         id="stop3756-9-3"
+         style="stop-color:#60cc00;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4806"
+       id="linearGradient3796"
+       x1="31.972326"
+       y1="3.8841453"
+       x2="31.972326"
+       y2="61.889656"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4806">
+      <stop
+         id="stop4808"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4810"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.42447853" />
+      <stop
+         id="stop4812"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.82089913" />
+      <stop
+         id="stop4814"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4510">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g3881">
+    <g
+       id="g3805">
+      <path
+         d="m 27.000001,28.499999 a 11,3.4999999 0 1 1 -21.9999996,0 11,3.4999999 0 1 1 21.9999996,0 z"
+         inkscape:connector-curvature="0"
+         id="path3818-0-2"
+         style="fill:url(#radialGradient3043);fill-opacity:1;stroke:none" />
+      <path
+         d="m 16,1.4999996 c -8.0006,0 -14.5,6.499399 -14.5,14.4999994 C 1.5,24.0006 7.9994,30.500003 16,30.5 24.0006,30.5 30.50001,24.0006 30.5,15.999999 30.5,7.9993986 24.0006,1.4999996 16,1.4999996 z"
+         inkscape:connector-curvature="0"
+         id="path2555-7-66"
+         style="color:#000000;fill:url(#radialGradient3040);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         d="m 16,1.4999996 c -8.0006,0 -14.5,6.499399 -14.5,14.4999994 C 1.5,24.0006 7.9994,30.500003 16,30.5 24.0006,30.5 30.50001,24.0006 30.5,15.999999 30.5,7.9993986 24.0006,1.4999996 16,1.4999996 z"
+         inkscape:connector-curvature="0"
+         id="path2555-7-1-7"
+         style="opacity:0.4;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999994000000003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path3035"
+         sodipodi:cx="11.384629"
+         sodipodi:cy="9.9830513"
+         sodipodi:rx="13.508475"
+         sodipodi:ry="13.508475"
+         d="m 24.893105,9.9830513 a 13.508475,13.508475 0 1 1 -27.0169511,0 13.508475,13.508475 0 1 1 27.0169511,0 z"
+         transform="translate(4.6153708,6.0169487)" />
+    </g>
+    <g
+       transform="matrix(0.5,0,0,0.5,-0.13609243,-0.29876934)"
+       id="g3882">
+      <g
+         id="g3869">
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="rect3883"
+           d="m 17.298088,40.902181 c 0.5927,-2.211986 2.511307,-2.908051 4.505133,-2.908051 3.046229,0 6.075666,0.293311 8.946667,1.062595 2.871,0.769281 5.750306,2.092963 8.279337,3.553099 1.726704,0.996913 2.991573,2.740627 2.412776,4.900726 -0.44672,1.667187 -2.298784,2.114913 -4.025488,1.117998 -2.504852,-1.446176 -5.408337,-2.783817 -8.279338,-3.553099 -2.871001,-0.769284 -5.985761,-1.062595 -8.946666,-1.062595 -1.993826,0 -3.339143,-1.443486 -2.892421,-3.110673 z"
+           style="opacity:0.9;fill:#1a1a1a;fill-opacity:1;stroke:none" />
+        <path
+           style="opacity:0.9;fill:#1a1a1a;fill-opacity:1;stroke:none"
+           d="m 14.48274,30.10568 c 0.592699,-2.211984 2.511306,-2.90805 4.505132,-2.908051 3.046229,1e-6 8.414615,0.369513 14.734347,2.06288 5.80609,1.555737 10.715029,3.816484 13.24406,5.276623 1.726704,0.996912 2.991575,2.740624 2.412777,4.900724 -0.446721,1.667187 -2.298785,2.114913 -4.025488,1.118 C 42.848715,39.10968 38.062352,36.874294 32.109506,35.279234 26.523547,33.78248 20.336065,33.216355 17.37516,33.216355 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110675 z"
+           id="path3895"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="path3897"
+           d="m 12.346123,19.69258 c 0.592699,-2.211986 2.511306,-2.908051 4.505132,-2.908051 3.046229,0 11.800505,0.647594 19.147517,2.61622 9.3282,2.499482 14.192548,5.220155 16.72158,6.680294 1.726704,0.996912 2.991572,2.740624 2.412776,4.900724 -0.446721,1.667186 -2.298785,2.114913 -4.02549,1.117999 C 48.602789,30.653589 40.045396,26.935888 34.38606,25.419475 27.99295,23.706446 18.199449,22.803253 15.238543,22.803253 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110673 z"
+           style="opacity:0.9;fill:#1a1a1a;fill-opacity:1;stroke:none" />
+      </g>
+      <g
+         id="g3874"
+         style="opacity:0.2;fill:#ffffff"
+         transform="translate(0,1.4142136)">
+        <path
+           style="opacity:0.9;fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 17.298088,40.902181 c 0.5927,-2.211986 2.511307,-2.908051 4.505133,-2.908051 3.046229,0 6.075666,0.293311 8.946667,1.062595 2.871,0.769281 5.750306,2.092963 8.279337,3.553099 1.726704,0.996913 2.991573,2.740627 2.412776,4.900726 -0.44672,1.667187 -2.298784,2.114913 -4.025488,1.117998 -2.504852,-1.446176 -5.408337,-2.783817 -8.279338,-3.553099 -2.871001,-0.769284 -5.985761,-1.062595 -8.946666,-1.062595 -1.993826,0 -3.339143,-1.443486 -2.892421,-3.110673 z"
+           id="path3876"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="path3878"
+           d="m 14.48274,30.10568 c 0.592699,-2.211984 2.511306,-2.90805 4.505132,-2.908051 3.046229,1e-6 8.414615,0.369513 14.734347,2.06288 5.80609,1.555737 10.715029,3.816484 13.24406,5.276623 1.726704,0.996912 2.991575,2.740624 2.412777,4.900724 -0.446721,1.667187 -2.298785,2.114913 -4.025488,1.118 C 42.848715,39.10968 38.062352,36.874294 32.109506,35.279234 26.523547,33.78248 20.336065,33.216355 17.37516,33.216355 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110675 z"
+           style="opacity:0.9;fill:#ffffff;fill-opacity:1;stroke:none" />
+        <path
+           style="opacity:0.9;fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 12.346123,19.69258 c 0.592699,-2.211986 2.511306,-2.908051 4.505132,-2.908051 3.046229,0 11.800505,0.647594 19.147517,2.61622 9.3282,2.499482 14.192548,5.220155 16.72158,6.680294 1.726704,0.996912 2.991572,2.740624 2.412776,4.900724 -0.446721,1.667186 -2.298785,2.114913 -4.02549,1.117999 C 48.602789,30.653589 40.045396,26.935888 34.38606,25.419475 27.99295,23.706446 18.199449,22.803253 15.238543,22.803253 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110673 z"
+           id="path3880"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/elementaryPlus/apps/64/spotify-client.svg
+++ b/elementaryPlus/apps/64/spotify-client.svg
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="64"
+   height="64"
+   id="svg4845"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="spotify.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1025"
+     id="namedview41"
+     showgrid="false"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="31.310913"
+     inkscape:cy="31.069332"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4845" />
+  <defs
+     id="defs4847">
+    <linearGradient
+       id="linearGradient4806">
+      <stop
+         id="stop4808"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4810"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.42447853" />
+      <stop
+         id="stop4812"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.82089913" />
+      <stop
+         id="stop4814"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3242-7-3-8-9">
+      <stop
+         id="stop3244-5-8-5-3"
+         style="stop-color:#eef87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9-5-1-2"
+         style="stop-color:#cde34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7-2-0-84"
+         style="stop-color:#93b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8-2-8-3"
+         style="stop-color:#5a7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="299.44821"
+       cy="-290.5918"
+       r="17.1528"
+       fx="297.44989"
+       fy="-289.9133"
+       id="XMLID_2_-8-6-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8232,0.2312,0.2703,-0.9626,-96.2274,-315.3433)">
+      <stop
+         id="stop228-2-7-9"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop230-7-5-7"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
+      <stop
+         id="stop3750-8-9"
+         style="stop-color:#8de53e;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3752-3-2"
+         style="stop-color:#95de55;stop-opacity:1;"
+         offset="0.26238" />
+      <stop
+         id="stop3754-7-2"
+         style="stop-color:#82de31;stop-opacity:1;"
+         offset="0.704952" />
+      <stop
+         id="stop3756-9-3"
+         style="stop-color:#60cc00;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3820-7-2">
+      <stop
+         id="stop3822-2-6"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3864-8-7"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         offset="0.5" />
+      <stop
+         id="stop3824-1-2"
+         style="stop-color:#686868;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="15.645058"
+       cy="8.449769"
+       r="19.99999"
+       fx="-0.22334664"
+       fy="8.44977"
+       id="radialGradient5007"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-9.6613255e-8,1.5876869,-1.495831,-1.0935756e-7,44.6396,2.8743392)" />
+    <linearGradient
+       x1="-1085.9586"
+       y1="539.40955"
+       x2="-474.68497"
+       y2="375.61926"
+       id="linearGradient5009"
+       xlink:href="#XMLID_2_-8-6-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1011621,0,0,0.08500722,118.6948,-5.5605522)" />
+    <radialGradient
+       cx="18.164446"
+       cy="8.449769"
+       r="19.99999"
+       fx="8.894803"
+       fy="8.5985041"
+       id="radialGradient5011"
+       xlink:href="#linearGradient3242-7-3-8-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.9915335,-1.8772441,-2.2997302e-8,47.862448,-4.4613112)" />
+    <linearGradient
+       x1="71.204407"
+       y1="15.369057"
+       x2="71.204407"
+       y2="40.495617"
+       id="linearGradient5013"
+       xlink:href="#linearGradient4806"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3268746,0,0,2.3268746,-135.94475,-32.842783)" />
+    <radialGradient
+       cx="99.157013"
+       cy="186.17059"
+       r="62.769119"
+       fx="99.157013"
+       fy="186.17059"
+       id="radialGradient5015"
+       xlink:href="#linearGradient3820-7-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.1666667,0,155.14216)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4806"
+       id="linearGradient3796"
+       x1="31.972326"
+       y1="3.8841453"
+       x2="31.972326"
+       y2="61.889656"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <metadata
+     id="metadata4850">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g3911">
+    <g
+       id="g3798">
+      <g
+         id="layer1">
+        <path
+           d="m 161.92613,186.17059 a 62.769119,10.461519 0 1 1 -125.538236,0 62.769119,10.461519 0 1 1 125.538236,0 z"
+           transform="matrix(0.38235362,0,0,0.71691308,-5.913044,-76.968133)"
+           id="path3818-0"
+           style="fill:url(#radialGradient5015);fill-opacity:1;stroke:none" />
+        <path
+           d="m 32,2.4999994 c -16.277082,0 -29.5,13.2229146 -29.5,29.4999976 0,16.277083 13.222918,29.500005 29.5,29.5 16.27708,0 29.50001,-13.222917 29.5,-29.5 C 61.5,15.722914 48.27708,2.4999994 32,2.4999994 z"
+           inkscape:connector-curvature="0"
+           id="path2555-7"
+           style="color:#000000;fill:url(#radialGradient5007);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+        <path
+           d="m 32,2.499999 c -16.277082,0 -29.5,13.222915 -29.5,29.499998 0,16.277083 13.222918,29.500005 29.5,29.5 16.27708,0 29.50001,-13.222917 29.5,-29.5 C 61.5,15.722914 48.27708,2.499999 32,2.499999 z"
+           inkscape:connector-curvature="0"
+           id="path2555-7-1"
+           style="opacity:0.4;color:#000000;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      </g>
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.40000000000000002;fill:none;stroke:url(#linearGradient3796);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;fill-opacity:1"
+         id="path3020"
+         sodipodi:cx="32.023548"
+         sodipodi:cy="32.935242"
+         sodipodi:rx="28.499874"
+         sodipodi:ry="28.499874"
+         d="m 60.523422,32.935242 a 28.499874,28.499874 0 1 1 -56.999748,0 28.499874,28.499874 0 1 1 56.999748,0 z"
+         transform="translate(-0.02354813,-0.9352417)" />
+    </g>
+    <g
+       id="g3882">
+      <g
+         id="g3869">
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="rect3883"
+           d="m 17.298088,40.902181 c 0.5927,-2.211986 2.511307,-2.908051 4.505133,-2.908051 3.046229,0 6.075666,0.293311 8.946667,1.062595 2.871,0.769281 5.750306,2.092963 8.279337,3.553099 1.726704,0.996913 2.991573,2.740627 2.412776,4.900726 -0.44672,1.667187 -2.298784,2.114913 -4.025488,1.117998 -2.504852,-1.446176 -5.408337,-2.783817 -8.279338,-3.553099 -2.871001,-0.769284 -5.985761,-1.062595 -8.946666,-1.062595 -1.993826,0 -3.339143,-1.443486 -2.892421,-3.110673 z"
+           style="opacity:0.9;fill:#1a1a1a;fill-opacity:1;stroke:none" />
+        <path
+           style="opacity:0.9;fill:#1a1a1a;fill-opacity:1;stroke:none"
+           d="m 14.48274,30.10568 c 0.592699,-2.211984 2.511306,-2.90805 4.505132,-2.908051 3.046229,1e-6 8.414615,0.369513 14.734347,2.06288 5.80609,1.555737 10.715029,3.816484 13.24406,5.276623 1.726704,0.996912 2.991575,2.740624 2.412777,4.900724 -0.446721,1.667187 -2.298785,2.114913 -4.025488,1.118 C 42.848715,39.10968 38.062352,36.874294 32.109506,35.279234 26.523547,33.78248 20.336065,33.216355 17.37516,33.216355 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110675 z"
+           id="path3895"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="path3897"
+           d="m 12.346123,19.69258 c 0.592699,-2.211986 2.511306,-2.908051 4.505132,-2.908051 3.046229,0 11.800505,0.647594 19.147517,2.61622 9.3282,2.499482 14.192548,5.220155 16.72158,6.680294 1.726704,0.996912 2.991572,2.740624 2.412776,4.900724 -0.446721,1.667186 -2.298785,2.114913 -4.02549,1.117999 C 48.602789,30.653589 40.045396,26.935888 34.38606,25.419475 27.99295,23.706446 18.199449,22.803253 15.238543,22.803253 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110673 z"
+           style="opacity:0.9;fill:#1a1a1a;fill-opacity:1;stroke:none" />
+      </g>
+      <g
+         id="g3874"
+         style="fill:#ffffff;opacity:0.2"
+         transform="translate(0,1.4142136)">
+        <path
+           style="opacity:0.90000000000000002;fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 17.298088,40.902181 c 0.5927,-2.211986 2.511307,-2.908051 4.505133,-2.908051 3.046229,0 6.075666,0.293311 8.946667,1.062595 2.871,0.769281 5.750306,2.092963 8.279337,3.553099 1.726704,0.996913 2.991573,2.740627 2.412776,4.900726 -0.44672,1.667187 -2.298784,2.114913 -4.025488,1.117998 -2.504852,-1.446176 -5.408337,-2.783817 -8.279338,-3.553099 -2.871001,-0.769284 -5.985761,-1.062595 -8.946666,-1.062595 -1.993826,0 -3.339143,-1.443486 -2.892421,-3.110673 z"
+           id="path3876"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="path3878"
+           d="m 14.48274,30.10568 c 0.592699,-2.211984 2.511306,-2.90805 4.505132,-2.908051 3.046229,1e-6 8.414615,0.369513 14.734347,2.06288 5.80609,1.555737 10.715029,3.816484 13.24406,5.276623 1.726704,0.996912 2.991575,2.740624 2.412777,4.900724 -0.446721,1.667187 -2.298785,2.114913 -4.025488,1.118 C 42.848715,39.10968 38.062352,36.874294 32.109506,35.279234 26.523547,33.78248 20.336065,33.216355 17.37516,33.216355 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110675 z"
+           style="opacity:0.90000000000000002;fill:#ffffff;fill-opacity:1;stroke:none" />
+        <path
+           style="opacity:0.90000000000000002;fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 12.346123,19.69258 c 0.592699,-2.211986 2.511306,-2.908051 4.505132,-2.908051 3.046229,0 11.800505,0.647594 19.147517,2.61622 9.3282,2.499482 14.192548,5.220155 16.72158,6.680294 1.726704,0.996912 2.991572,2.740624 2.412776,4.900724 -0.446721,1.667186 -2.298785,2.114913 -4.02549,1.117999 C 48.602789,30.653589 40.045396,26.935888 34.38606,25.419475 27.99295,23.706446 18.199449,22.803253 15.238543,22.803253 c -1.993826,0 -3.339141,-1.443488 -2.89242,-3.110673 z"
+           id="path3880"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Updates old Spotify icon. Preview of new updated icons:
![spotify-preview2](https://cloud.githubusercontent.com/assets/10608836/14621768/b906d638-058a-11e6-9d97-4f8966842881.png)
vs. Old icon:
![old-spotify](https://cloud.githubusercontent.com/assets/10608836/14621750/9ffc0136-058a-11e6-8bf5-cfe2f5b29b47.png)
