### PR TITLE
Fixed "Binary/Static File" for Telegram Desktop

### DIFF
--- a/scripts/elementaryplus-installer.py
+++ b/scripts/elementaryplus-installer.py
@@ -172,7 +172,7 @@ iconMegaList = [
     [
         "Telegram Desktop",
         "",
-        "%s/.TelegramDesktop/tdata/icon.png" % (home),
+        "%s/.TelegramDesktop/tdata" % (home),
         "Telegram is a messaging app with a focus on speed and security, it's super fast, simple and free",
         "telegram",
         "custom"


### PR DESCRIPTION
Changed `%s/.TelegramDesktop/tdata/icon.png` to `%s/.TelegramDesktop/tdata`.
This should fix issue #376.