### PR TITLE
Add updated Brackets icon

### DIFF
--- a/elementaryPlus/apps/128/brackets.svg
+++ b/elementaryPlus/apps/128/brackets.svg
@@ -14,7 +14,7 @@
    width="128"
    height="128"
    id="svg3049"
-   inkscape:version="0.48+devel r"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="brackets.svg">
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -25,19 +25,34 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1025"
+     inkscape:window-width="1280"
+     inkscape:window-height="744"
      id="namedview51"
      showgrid="false"
      inkscape:zoom="1"
-     inkscape:cx="0.61356096"
-     inkscape:cy="55.861641"
+     inkscape:cx="60.703535"
+     inkscape:cy="30.223608"
      inkscape:window-x="0"
      inkscape:window-y="30"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg3049" />
+     inkscape:current-layer="svg3049"
+     inkscape:object-nodes="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-midpoints="true" />
   <defs
      id="defs3051">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3767">
+      <stop
+         style="stop-color:#414141;stop-opacity:1"
+         offset="0"
+         id="stop3769" />
+      <stop
+         style="stop-color:#505050;stop-opacity:1"
+         offset="1"
+         id="stop3771" />
+    </linearGradient>
     <linearGradient
        id="linearGradient3924">
       <stop
@@ -66,7 +81,7 @@
        id="radialGradient4093"
        xlink:href="#linearGradient3688-166-749-5"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,-46.922772,70.542038)" />
     <linearGradient
        id="linearGradient3688-166-749-5">
       <stop
@@ -87,7 +102,7 @@
        id="radialGradient4095"
        xlink:href="#linearGradient3688-464-309-8"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,69.592142,-157.54203)" />
     <linearGradient
        id="linearGradient3688-464-309-8">
       <stop
@@ -106,7 +121,8 @@
        y2="39.999443"
        id="linearGradient4097"
        xlink:href="#linearGradient3702-501-757-0"
-       gradientUnits="userSpaceOnUse" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8421052,0,0,0.71428566,-126.46798,82.970608)" />
     <linearGradient
        id="linearGradient3702-501-757-0">
       <stop
@@ -142,40 +158,7 @@
        id="radialGradient6276"
        xlink:href="#linearGradient3811"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5563924,0,0,0.16978827,70.270355,102.1321)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4552"
-       id="linearGradient4620"
-       gradientUnits="userSpaceOnUse"
-       x1="20.375"
-       y1="34.5625"
-       x2="20.375"
-       y2="15.25"
-       gradientTransform="matrix(2.6410256,0,0,2.6410256,-122.23212,0.97618945)" />
-    <linearGradient
-       id="linearGradient4552"
-       inkscape:collect="always">
-      <stop
-         id="stop4554"
-         offset="0"
-         style="stop-color:#333333;stop-opacity:1" />
-      <stop
-         id="stop4556"
-         offset="1"
-         style="stop-color:#4d4d4d;stop-opacity:1" />
-    </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-4"
-       id="radialGradient4616"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,25.083279,-30.794253,0,249.96907,-208.08999)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
-       fy="9.9571075"
-       r="12.671875" />
+       gradientTransform="matrix(1.5563924,0,0,0.16978827,-51.987094,97.672326)" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-4">
       <stop
@@ -195,45 +178,102 @@
          style="stop-color:#0274bd;stop-opacity:1"
          offset="1" />
     </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.5563924,0,0,0.16978827,70.270353,99.13029)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3811"
+       id="radialGradient6276-3"
+       fy="93.467628"
+       fx="-4.0287771"
+       r="35.338131"
+       cy="93.467628"
+       cx="-4.0287771" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-5"
+       id="radialGradient4093-5"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-5"
+       id="radialGradient4095-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-0"
+       id="linearGradient4097-1"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <radialGradient
+       cx="7.8500957"
+       cy="9.9571075"
+       r="12.671875"
+       fx="7.3198657"
+       fy="9.9571075"
+       id="radialGradient5521-1"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,15.631225,-30.794253,0,372.81654,-143.21941)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         id="stop3750-8-9" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#42baea;stop-opacity:1"
+         id="stop3752-3-2" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#4b9eeb;stop-opacity:1"
+         id="stop3754-7-2" />
+      <stop
+         offset="1"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         id="stop3756-9-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135047,-1.51349)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924"
+       id="linearGradient4136"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4552"
-       id="linearGradient4277"
+       xlink:href="#linearGradient3767"
+       id="linearGradient4277-2-3"
        gradientUnits="userSpaceOnUse"
        x1="20.375"
        y1="34.5625"
        x2="20.375"
        y2="15.25"
-       gradientTransform="matrix(-2.6410256,0,0,2.6410256,4.5422582,0.97618945)" />
+       gradientTransform="matrix(-2.5939687,0,0,2.5932888,127.74494,-2.3324641)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3924"
-       id="linearGradient4357"
+       xlink:href="#linearGradient3767"
+       id="linearGradient4277-2-3-1"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,-124.36098,1.4883161)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3924"
-       id="linearGradient4408"
-       x1="-75.218483"
-       y1="38.374214"
-       x2="-75.218483"
-       y2="95.561478"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3924"
-       id="linearGradient4412"
-       gradientUnits="userSpaceOnUse"
-       x1="-75.218483"
-       y1="38.374214"
-       x2="-75.218483"
-       y2="95.561478"
-       gradientTransform="matrix(-1,0,0,1,-117.69017,0)" />
+       x1="20.375"
+       y1="34.5625"
+       x2="20.375"
+       y2="15.25"
+       gradientTransform="matrix(2.5939687,0,0,2.5932888,0.25506,-2.332464)" />
   </defs>
   <metadata
      id="metadata3054">
@@ -243,180 +283,123 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient6276);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     id="path3041"
      inkscape:connector-curvature="0"
-     d="m 119,118.00181 a 55,6 0 0 1 -109.9999975,0 55,6 0 1 1 109.9999975,0 z" />
+     d="m 119,115 a 55,6 0 0 1 -110,0 55,6 0 1 1 110,0 z"
+     id="path3041-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient6276-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
   <g
-     style="display:inline"
+     transform="matrix(2.6999989,0,0,0.55555607,-0.8000006,91.88888)"
      id="g2036"
-     transform="matrix(2.6999989,0,0,0.55555607,-0.8000075,94.890689)">
+     style="display:inline">
     <g
-       style="opacity:0.4"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
        id="g3712"
-       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+       style="opacity:0.4">
       <rect
-         style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none"
-         id="rect2801"
-         y="40"
+         width="5"
+         height="7"
          x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none"
-         id="rect3696"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none"
-         id="rect3700"
          y="40"
-         x="10"
+         id="rect2801-2"
+         style="fill:url(#radialGradient4093-5);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1,-1)"
+         id="rect3696-6"
+         style="fill:url(#radialGradient4095-6);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
          height="7.0000005"
-         width="28" />
+         x="10"
+         y="40"
+         id="rect3700-1"
+         style="fill:url(#linearGradient4097-1);fill-opacity:1;stroke:none" />
     </g>
   </g>
-  <g
-     id="g4414"
-     transform="translate(122.84746,2.8610229e-6)">
-    <rect
-       width="103"
-       height="103"
-       rx="5.2820511"
-       ry="5.2820511"
-       x="-110.34747"
-       y="15.501805"
-       id="rect4566"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4616);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
-    <rect
-       width="103"
-       height="103"
-       rx="5.2820511"
-       ry="5.2820511"
-       x="-110.34747"
-       y="15.501805"
-       id="rect4570"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#004471;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <path
-       inkscape:connector-curvature="0"
-       id="rect4572"
-       d="m -95.584833,26.065906 73.474706,0 c 2.325978,0 4.198544,1.872567 4.198544,4.198571 l 0,73.474683 c 0,2.326 -1.872566,4.19854 -4.198544,4.19854 l -73.474706,0 c -2.325977,0 -4.198544,-1.87254 -4.198544,-4.19854 l 0,-73.474683 c 0,-2.326004 1.872567,-4.198571 4.198544,-4.198571 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fefefe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
-    <g
-       id="g4389">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m -52.714844,38.976218 0,0.5 0,12.611329 9.423828,0 0,31.96289 -9.423828,0 0,13.976563 23.400391,0 0,-59.050782 z"
-         id="path4375"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m -88.375,38.976218 0,59.050782 23.398438,0 0,-13.976563 -9.423829,0 0,-31.96289 9.423829,0 0,-13.111329 -0.5,0 z"
-         id="path4377"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
-    </g>
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4578"
-       d="m -65.475917,38.977455 0,12.110505 -9.42356,0 0,32.963203 9.42356,0 0,12.975538 -22.399101,0 0,-58.049246 z"
-       inkscape:connector-curvature="0"
-       style="opacity:0.3;fill:#333333;stroke:#333333;stroke-width:0.99999994" />
-    <path
-       style="opacity:0.3;fill:#333333;stroke:#333333;stroke-width:0.99999994"
-       inkscape:connector-curvature="0"
-       d="m -52.213944,38.977455 0,12.110505 9.423559,0 0,32.963203 -9.423559,0 0,12.975538 22.3991,0 0,-58.049246 z"
-       id="path4245"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       style="fill:url(#linearGradient4277);fill-opacity:1"
-       inkscape:connector-curvature="0"
-       d="m -52.213944,37.977455 0,12.110504 9.423559,0 0,32.963203 -9.423559,0 0,12.975539 22.3991,0 0,-58.049246 z"
-       id="path4247"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4249"
-       d="m -52.213944,37.977455 0,12.110504 9.423559,0 0,32.963203 -9.423559,0 0,12.975539 22.3991,0 0,-58.049246 z"
-       inkscape:connector-curvature="0"
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99999994" />
-    <g
-       style="opacity:0.3;fill:none;stroke:none;stroke-width:1.08245623;stroke-miterlimit:4;stroke-dasharray:none"
-       id="g4588"
-       transform="matrix(2.4398451,0,0,2.4398451,-234.68887,6.4382001)">
-      <g
-         style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-         transform="matrix(0.35454545,0,0,0.35454545,49.73436,4.4363587)"
-         id="g4590">
-        <g
-           style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-           id="g4592">
-          <path
-             id="path4594"
-             d="m 59,27 0,14 -17,0 0,32 17,0 0,15 -32,0 0,-61 32,0 z"
-             inkscape:connector-curvature="0"
-             style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none" />
-        </g>
-      </g>
-      <g
-         style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-         transform="matrix(0.35454545,0,0,0.35454545,49.73436,4.4363587)"
-         id="g4596">
-        <g
-           style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-           id="g4598">
-          <path
-             id="path4600"
-             d="m 99,27 0,61 -32,0 0,-15 18,0 0,-32 -18,0 0,-14 32,0 z"
-             inkscape:connector-curvature="0"
-             style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none" />
-        </g>
-      </g>
-    </g>
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4584"
-       d="m -65.475917,37.977455 0,12.110504 -9.42356,0 0,32.963203 9.42356,0 0,12.975539 -22.399101,0 0,-58.049246 z"
-       inkscape:connector-curvature="0"
-       style="fill:url(#linearGradient4620);fill-opacity:1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99999994"
-       inkscape:connector-curvature="0"
-       d="m -65.475917,37.977455 0,12.110504 -9.42356,0 0,32.963203 9.42356,0 0,12.975539 -22.399101,0 0,-58.049246 z"
-       id="path4602"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#004471;stroke-width:0.99999988;stroke-opacity:1;marker:none;enable-background:accumulate"
-       d="m -95.584833,26.065906 73.474706,0 c 2.325978,0 4.198544,1.872567 4.198544,4.198571 l 0,73.474683 c 0,2.326 -1.872566,4.19854 -4.198544,4.19854 l -73.474706,0 c -2.325977,0 -4.198544,-1.87254 -4.198544,-4.19854 l 0,-73.474683 c 0,-2.326004 1.872567,-4.198571 4.198544,-4.198571 z"
-       id="path4629"
-       inkscape:connector-curvature="0" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient4357);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="rect4355"
-       y="16.501804"
-       x="-109.34747"
-       ry="5"
-       rx="5"
-       height="101"
-       width="101" />
-    <path
-       id="path4393"
-       d="m -86.875,38.976562 0,56.050782 20.398438,0 0,-10.976563 -9.423829,0 0,-34.96289 9.423829,0 0,-10.111329 -20.398438,0 z"
-       style="opacity:0.5;fill:none;fill-opacity:1;stroke:url(#linearGradient4408)"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:connector-curvature="0"
-       style="opacity:0.5;fill:none;fill-opacity:1;stroke:url(#linearGradient4412)"
-       d="m -30.815175,38.976562 0,56.050782 -20.398438,0 0,-10.976563 9.423829,0 0,-34.96289 -9.423829,0 0,-10.111329 20.398438,0 z"
-       id="path4410" />
-  </g>
+  <rect
+     width="103"
+     height="103"
+     rx="6.0545406"
+     ry="6.0545406"
+     x="12.5"
+     y="12.500008"
+     id="rect5505-21-3"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5521-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <rect
+     width="101"
+     height="101"
+     rx="5"
+     ry="5"
+     x="13.5"
+     y="13.500008"
+     id="rect6741-7"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient4136);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     width="103"
+     height="103"
+     rx="6.0545406"
+     ry="6.0545406"
+     x="12.5"
+     y="12.500008"
+     id="rect5505-21-3-1"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#004264;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.07000002;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="m 27.205124,24.000001 73.589756,0 c 2.32962,0 4.20511,1.875499 4.20511,4.205145 l 0,73.589734 c 0,2.32965 -1.87549,4.20512 -4.20511,4.20512 l -73.589756,0 C 24.875502,106 23,104.12453 23,101.79488 l 0,-73.589734 c 0,-2.329646 1.875502,-4.205145 4.205124,-4.205145 z"
+     id="rect4572-7-9"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     d="m 27.205124,24.000003 73.589756,0 c 2.32962,0 4.20512,1.875499 4.20512,4.205145 l 0,73.589732 C 105,104.12453 103.1245,106 100.79488,106 l -73.589756,0 C 24.875502,106 23,104.12453 23,101.79488 l 0,-73.589732 c 0,-2.329646 1.875502,-4.205145 4.205124,-4.205145 z"
+     id="rect4572-7"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fefefe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     d="m 27.205124,23.000004 73.589756,0 c 2.32962,0 4.20512,1.875499 4.20512,4.205145 l 0,73.589731 C 105,103.12453 103.1245,105 100.79488,105 l -73.589756,0 C 24.875502,105 23,103.12453 23,100.79488 l 0,-73.589731 c 0,-2.329646 1.875502,-4.205145 4.205124,-4.205145 z"
+     id="rect4572"
+     inkscape:connector-curvature="0" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-3-5-2-9"
+     d="m 70,35 0,12 11,0 0,36 -11,0 0,12 24,0 0,-60 z"
+     inkscape:connector-curvature="0"
+     style="opacity:0.07;fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-3-5-2"
+     d="m 70,35 0,12 11,0 0,36 -11,0 0,12 24,0 0,-60 z"
+     inkscape:connector-curvature="0"
+     style="fill:#000000;fill-opacity:1;opacity:0.15" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-3-5"
+     d="m 70,34 0,12 11,0 0,36 -11,0 0,12 24,0 0,-60 z"
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient4277-2-3);fill-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-3-5-2-9-0"
+     d="m 58,35 0,12 -11,0 0,36 11,0 0,12 -24,0 0,-60 z"
+     inkscape:connector-curvature="0"
+     style="opacity:0.07000002;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-3-5-2-93"
+     d="m 58,35 0,12 -11,0 0,36 11,0 0,12 -24,0 0,-60 z"
+     inkscape:connector-curvature="0"
+     style="opacity:0.15;fill:#000000;fill-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-3-5-6"
+     d="m 58,34 0,12 -11,0 0,36 11,0 0,12 -24,0 0,-60 z"
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient4277-2-3-1);fill-opacity:1" />
 </svg>

--- a/elementaryPlus/apps/16/brackets.svg
+++ b/elementaryPlus/apps/16/brackets.svg
@@ -14,7 +14,7 @@
    width="16"
    height="16"
    id="svg7357"
-   inkscape:version="0.48+devel r"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="brackets.svg">
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -25,19 +25,33 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1025"
+     inkscape:window-width="1280"
+     inkscape:window-height="744"
      id="namedview28"
      showgrid="false"
      inkscape:zoom="1"
-     inkscape:cx="-1.1844457"
-     inkscape:cy="6.1727969"
+     inkscape:cx="0.6214876"
+     inkscape:cy="8"
      inkscape:window-x="0"
      inkscape:window-y="30"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg7357" />
+     inkscape:current-layer="svg7357"
+     inkscape:object-nodes="true"
+     inkscape:snap-midpoints="true" />
   <defs
      id="defs7359">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3749">
+      <stop
+         style="stop-color:#3c3c3c;stop-opacity:1"
+         offset="0"
+         id="stop3751" />
+      <stop
+         style="stop-color:#505050;stop-opacity:1"
+         offset="1"
+         id="stop3753" />
+    </linearGradient>
     <linearGradient
        x1="23.99999"
        y1="4.999989"
@@ -134,59 +148,76 @@
          style="stop-color:#0274bd;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-6"
-       id="radialGradient4616"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,3.1658508,-3.8866534,0,31.909052,-26.838969)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
-       fy="9.9571075"
-       r="12.671875" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4552"
-       id="linearGradient4267"
-       gradientUnits="userSpaceOnUse"
-       x1="20.375"
-       y1="34.5625"
-       x2="20.375"
-       y2="15.25"
-       gradientTransform="matrix(-0.33333334,0,0,0.33333334,0.93285166,-0.45197611)" />
     <linearGradient
        id="linearGradient4552"
        inkscape:collect="always">
       <stop
          id="stop4554"
          offset="0"
-         style="stop-color:#333333;stop-opacity:1" />
+         style="stop-color:#3c3c3c;stop-opacity:1" />
       <stop
          id="stop4556"
          offset="1"
-         style="stop-color:#4d4d4d;stop-opacity:1" />
+         style="stop-color:#505050;stop-opacity:1" />
     </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0,1.972873,-3.8866533,0,46.976838,-18.153911)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       id="radialGradient5521-1"
+       fy="9.9571075"
+       fx="7.3198657"
+       r="12.671875"
+       cy="9.9571075"
+       cx="7.8500957" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
+      <stop
+         id="stop3750-8-9"
+         style="stop-color:#90dbec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-2"
+         style="stop-color:#42baea;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-7-2"
+         style="stop-color:#4299ea;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-9-3"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient4224-3"
+       xlink:href="#linearGradient3924-4-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2972973,0,0,0.2972973,0.86486738,0.86487004)" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4552"
-       id="linearGradient4620"
+       id="linearGradient4267-6"
        gradientUnits="userSpaceOnUse"
        x1="20.375"
        y1="34.5625"
        x2="20.375"
        y2="15.25"
-       gradientTransform="matrix(0.33333334,0,0,0.33333334,-15.0678,-0.45197611)" />
+       gradientTransform="matrix(0.35372299,0,0,0.34495052,-0.60158152,-0.41477096)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3924-4-8"
-       id="linearGradient4411"
+       xlink:href="#linearGradient3749"
+       id="linearGradient4267-6-6"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2972973,0,0,0.2972973,-14.202927,0.74622584)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
+       x1="20.375"
+       y1="34.5625"
+       x2="20.375"
+       y2="15.25"
+       gradientTransform="matrix(-0.35372299,0,0,0.34495052,16.601582,-0.41477082)" />
   </defs>
   <metadata
      id="metadata7362">
@@ -196,131 +227,74 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="g4425"
-     transform="translate(15.067798,0.11864293)">
-    <rect
-       width="13"
-       height="13"
-       rx="0.66666669"
-       ry="0.66666669"
-       x="-13.567797"
-       y="1.3813556"
-       id="rect4566"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4616);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient4411);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="rect4409"
-       y="2.3813558"
-       x="-12.567797"
-       height="11"
-       width="11" />
-    <rect
-       width="13"
-       height="13"
-       rx="0.66666669"
-       ry="0.66666669"
-       x="-13.567797"
-       y="1.3813556"
-       id="rect4570"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#004471;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <path
-       inkscape:connector-curvature="0"
-       id="rect4572"
-       d="m -11.704548,2.7146889 9.2735043,0 c 0.2935723,0 0.5299143,0.2363421 0.5299143,0.5299148 l 0,9.2735043 c 0,0.293572 -0.236342,0.529915 -0.5299143,0.529915 l -9.2735043,0 c -0.293573,0 -0.529915,-0.236343 -0.529915,-0.529915 l 0,-9.2735043 c 0,-0.2935727 0.236342,-0.5299148 0.529915,-0.5299148 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fefefe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
-    <g
-       id="g4421">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m -6.7304688,5.1938284 0,0.5 0,2.0292968 1.1894532,0 0,3.1601558 -1.1894532,0 0,2.636719 3.8261719,0 0,-8.3261716 z"
-         id="path4413"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m -11.232422,5.1938284 0,8.3261716 3.8281251,0 0,-2.636719 -1.1894531,0 0,-3.1601558 1.1894531,0 0,-2.5292968 -0.5,0 z"
-         id="path4415"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
-    </g>
-    <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#004471;stroke-width:0.99999988;stroke-opacity:1;marker:none;enable-background:accumulate"
-       d="m -11.704548,2.7146889 9.2735043,0 c 0.2935723,0 0.5299143,0.2363421 0.5299143,0.5299148 l 0,9.2735043 c 0,0.293572 -0.236342,0.529915 -0.5299143,0.529915 l -9.2735043,0 c -0.293573,0 -0.529915,-0.236343 -0.529915,-0.529915 l 0,-9.2735043 c 0,-0.2935727 0.236342,-0.5299148 0.529915,-0.5299148 z"
-       id="path4629"
-       inkscape:connector-curvature="0" />
-    <path
-       style="opacity:0.3;fill:#333333;stroke:#333333;stroke-width:1"
-       inkscape:connector-curvature="0"
-       d="m -6.2305528,5.1933965 0,1.5285104 1.1893814,0 0,4.1604041 -1.1893814,0 0,1.637689 2.8270711,0 0,-7.3266035 z"
-       id="path4245"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       style="fill:url(#linearGradient4267);fill-opacity:1"
-       inkscape:connector-curvature="0"
-       d="m -6.2305528,4.2180866 0,1.5285104 1.1893814,0 0,4.1604045 -1.1893814,0 0,1.6376895 2.8270711,0 0,-7.3266044 z"
-       id="path4247"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4249"
-       d="m -6.2305528,4.2180866 0,1.5285104 1.1893814,0 0,4.1604045 -1.1893814,0 0,1.6376895 2.8270711,0 0,-7.3266044 z"
-       inkscape:connector-curvature="0"
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1" />
-    <g
-       style="opacity:0.3;fill:none;stroke:none;stroke-width:1.08245623;stroke-miterlimit:4;stroke-dasharray:none"
-       id="g4588"
-       transform="matrix(0.30794162,0,0,0.30794162,-29.26137,0.2374065)">
-      <g
-         style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-         transform="matrix(0.35454545,0,0,0.35454545,49.73436,4.4363587)"
-         id="g4590">
-        <g
-           style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-           id="g4592">
-          <path
-             id="path4594"
-             d="m 59,27 0,14 -17,0 0,32 17,0 0,15 -32,0 0,-61 32,0 z"
-             inkscape:connector-curvature="0"
-             style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none" />
-        </g>
-      </g>
-      <g
-         style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-         transform="matrix(0.35454545,0,0,0.35454545,49.73436,4.4363587)"
-         id="g4596">
-        <g
-           style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-           id="g4598">
-          <path
-             id="path4600"
-             d="m 99,27 0,61 -32,0 0,-15 18,0 0,-32 -18,0 0,-14 32,0 z"
-             inkscape:connector-curvature="0"
-             style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none" />
-        </g>
-      </g>
-    </g>
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4578"
-       d="m -7.9043954,5.1933965 0,1.5285104 -1.1893816,0 0,4.1604041 1.1893816,0 0,1.637689 -2.8270706,0 0,-7.3266035 z"
-       inkscape:connector-curvature="0"
-       style="opacity:0.3;fill:#333333;stroke:#333333;stroke-width:1" />
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4584"
-       d="m -7.9043954,4.2180866 0,1.5285104 -1.1893816,0 0,4.1604045 1.1893816,0 0,1.6376895 -2.8270706,0 0,-7.3266044 z"
-       inkscape:connector-curvature="0"
-       style="fill:url(#linearGradient4620);fill-opacity:1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1"
-       inkscape:connector-curvature="0"
-       d="m -7.9043954,4.2180866 0,1.5285104 -1.1893816,0 0,4.1604045 1.1893816,0 0,1.6376895 -2.8270706,0 0,-7.3266044 z"
-       id="path4602"
-       sodipodi:nodetypes="ccccccccc" />
-  </g>
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5521-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="rect5505-21-2"
+     y="1.4999986"
+     x="1.4999986"
+     ry="1"
+     rx="1"
+     height="13.000003"
+     width="13.000003" />
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#004264;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="rect5505-21-2-8"
+     y="1.4999986"
+     x="1.4999986"
+     ry="1"
+     rx="1"
+     height="13.000003"
+     width="13.000003" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient4224-3);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-0-3"
+     y="2.5"
+     x="2.5"
+     height="11"
+     width="11" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fefefe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     d="m 3.5128209,3.0000003 8.9743591,0 C 12.771282,3.0000003 13,3.2287184 13,3.512821 l 0,8.974358 C 13,12.771281 12.771282,13 12.48718,13 L 3.5128209,13 C 3.228718,13 3,12.771281 3,12.487179 L 3,3.512821 C 3,3.2287184 3.228718,3.0000003 3.5128209,3.0000003 Z"
+     id="rect4572-5"
+     inkscape:connector-curvature="0" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-1-9-3"
+     d="m 6.9999998,4.9999982 0,2 -0.9999998,0 0,4.0000008 0.9999998,0 0,2.000001 L 4,13 4,4.9999982 Z"
+     inkscape:connector-curvature="0"
+     style="opacity:0.07000002;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-1-9"
+     d="m 6.9999998,4.999999 0,2 -0.9999998,0 0,4 0.9999998,0 0,2.000001 L 4,13 4,4.999999 Z"
+     inkscape:connector-curvature="0"
+     style="opacity:0.15;fill:#000000;fill-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-1"
+     d="m 6.9999998,3.999999 0,2 -0.9999998,0 0,4 0.9999998,0 0,2.000001 L 4,12 4,3.999999 Z"
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient4267-6);fill-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-1-9-3-2"
+     d="m 9,4.9999988 0,2 1,0 0,4.0000002 -1,0 L 9,13 l 3,0 0,-8.0000012 z"
+     inkscape:connector-curvature="0"
+     style="opacity:0.07000002;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-1-9-6"
+     d="m 9,4.9999988 0,2 1,0 0,4.0000002 -1,0 L 9,13 l 3,0 0,-8.0000012 z"
+     inkscape:connector-curvature="0"
+     style="opacity:0.15;fill:#000000;fill-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-1-1"
+     d="m 9,3.9999992 0,1.9999996 1,0 0,4 -1,0 L 9,12 l 3,0 0,-8.0000008 z"
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient4267-6-6);fill-opacity:1" />
 </svg>

--- a/elementaryPlus/apps/24/brackets.svg
+++ b/elementaryPlus/apps/24/brackets.svg
@@ -14,7 +14,7 @@
    width="24"
    height="24"
    id="svg7107"
-   inkscape:version="0.48+devel r"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="brackets.svg">
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -25,19 +25,32 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1025"
+     inkscape:window-width="1280"
+     inkscape:window-height="744"
      id="namedview46"
      showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="12"
+     inkscape:zoom="25.208333"
+     inkscape:cx="0.93223123"
      inkscape:cy="12"
      inkscape:window-x="0"
      inkscape:window-y="30"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg7107" />
+     inkscape:current-layer="svg7107"
+     inkscape:object-nodes="true" />
   <defs
      id="defs7109">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3770">
+      <stop
+         style="stop-color:#3c3c3c;stop-opacity:1"
+         offset="0"
+         id="stop3772" />
+      <stop
+         style="stop-color:#505050;stop-opacity:1"
+         offset="1"
+         id="stop3774" />
+    </linearGradient>
     <linearGradient
        x1="23.99999"
        y1="4.999989"
@@ -180,17 +193,6 @@
          style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-9"
-       id="radialGradient4616"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,4.6270127,-5.6804934,0,46.033959,-39.906107)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
-       fy="9.9571075"
-       r="12.671875" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-9">
       <stop
@@ -211,78 +213,104 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4552"
-       id="linearGradient4267"
-       gradientUnits="userSpaceOnUse"
-       x1="20.375"
-       y1="34.5625"
-       x2="20.375"
-       y2="15.25"
-       gradientTransform="matrix(-0.48717949,0,0,0.48717949,0.76105035,-1.3405021)" />
-    <linearGradient
        id="linearGradient4552"
        inkscape:collect="always">
       <stop
          id="stop4554"
          offset="0"
-         style="stop-color:#333333;stop-opacity:1" />
+         style="stop-color:#3c3c3c;stop-opacity:1" />
       <stop
          id="stop4556"
          offset="1"
-         style="stop-color:#4d4d4d;stop-opacity:1" />
+         style="stop-color:#505050;stop-opacity:1" />
     </linearGradient>
     <linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.97295815,0.97175021)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924-64"
+       id="linearGradient5397-6"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
+    <radialGradient
+       cx="7.8500957"
+       cy="9.9571075"
+       r="12.671875"
+       fx="7.3198657"
+       fy="9.9571075"
+       id="radialGradient5521-1"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.8834298,-5.6804933,0,68.966148,-26.22492)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         id="stop3750-8-9" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#42baea;stop-opacity:1"
+         id="stop3752-3-2" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#4299ea;stop-opacity:1"
+         id="stop3754-7-2" />
+      <stop
+         offset="1"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         id="stop3756-9-3" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-9"
+       id="radialGradient3082-6-2"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-9"
+       id="radialGradient3084-4-3"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4552"
-       id="linearGradient4620"
+       xlink:href="#linearGradient3702-501-757-1"
+       id="linearGradient3905"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3770"
+       id="linearGradient4620-3"
        gradientUnits="userSpaceOnUse"
        x1="20.375"
        y1="34.5625"
        x2="20.375"
        y2="15.25"
-       gradientTransform="matrix(0.48717949,0,0,0.48717949,-22.624517,-1.3405021)" />
+       gradientTransform="matrix(0.48717949,0,0,0.48717949,0.66228204,-0.53358929)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3924-64"
-       id="linearGradient4327"
+       xlink:href="#linearGradient4552"
+       id="linearGradient4620-3-0"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.45945947,0,0,0.45945947,-21.959236,-0.18801555)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4364"
-       id="linearGradient4370"
-       x1="-15.234375"
-       y1="7.015625"
-       x2="-15.234375"
-       y2="14.53125"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4364">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop4366" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4368" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4364"
-       id="linearGradient4374"
-       gradientUnits="userSpaceOnUse"
-       x1="-15.234375"
-       y1="7.015625"
-       x2="-15.234375"
-       y2="14.53125"
-       gradientTransform="translate(8.7091694,0)" />
+       x1="20.375"
+       y1="34.5625"
+       x2="20.375"
+       y2="15.25"
+       gradientTransform="matrix(-0.48717949,0,0,0.48717949,23.337719,-0.5335894)" />
   </defs>
   <metadata
      id="metadata7112">
@@ -292,185 +320,106 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="display:inline"
-     id="g2036-4"
-     transform="matrix(0.55,0,0,0.3333336,-1.2000011,7.33333)">
+     transform="matrix(0.55,0,0,0.3333336,-1.2000055,7.3333303)"
+     id="g2036-4-8"
+     style="display:inline">
     <g
-       style="opacity:0.4"
-       id="g3712-8"
-       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712-8-9"
+       style="opacity:0.4">
       <rect
-         style="fill:url(#radialGradient3082-6);fill-opacity:1;stroke:none"
-         id="rect2801-6"
-         y="40"
+         width="5"
+         height="7"
          x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient3084-4);fill-opacity:1;stroke:none"
-         id="rect3696-20"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none"
-         id="rect3700-5"
          y="40"
-         x="10"
+         id="rect2801-6-7"
+         style="fill:url(#radialGradient3082-6-2);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1,-1)"
+         id="rect3696-20-3"
+         style="fill:url(#radialGradient3084-4-3);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
          height="7.0000005"
-         width="28" />
+         x="10"
+         y="40"
+         id="rect3700-5-6"
+         style="fill:url(#linearGradient3905);fill-opacity:1;stroke:none" />
     </g>
   </g>
-  <g
-     id="g4402"
-     transform="translate(22.932204,1.161044)">
-    <rect
-       width="19"
-       height="19"
-       rx="0.97435898"
-       ry="0.97435898"
-       x="-20.432205"
-       y="1.3389827"
-       id="rect4566"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4616);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
-    <rect
-       width="19"
-       height="19"
-       rx="0.97435898"
-       ry="0.97435898"
-       x="-20.432205"
-       y="1.3389827"
-       id="rect4570"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#004471;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <path
-       inkscape:connector-curvature="0"
-       id="rect4572"
-       d="m -17.708995,3.2877006 13.5535829,0 c 0.4290672,0 0.7744901,0.345423 0.7744901,0.7744908 l 0,13.5535836 c 0,0.429067 -0.3454229,0.77449 -0.7744901,0.77449 l -13.5535829,0 c -0.429068,0 -0.774491,-0.345423 -0.774491,-0.77449 l 0,-13.5535836 c 0,-0.4290678 0.345423,-0.7744908 0.774491,-0.7744908 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fefefe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
-    <g
-       id="g4390">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m -10.208984,6.4729682 0,0.5 0,2.7324219 1.7382809,0 0,5.0820309 -1.7382809,0 0,3.392579 5.1328121,0 0,-11.7070318 z"
-         id="path4376"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m -16.787109,6.4729682 0,11.7070318 5.132812,0 0,-3.392579 -1.738281,0 0,-5.0820309 1.738281,0 0,-3.2324219 -0.5,0 z"
-         id="path4378"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
-    </g>
-    <path
-       style="opacity:0.3;fill:#333333;stroke:#333333;stroke-width:1"
-       inkscape:connector-curvature="0"
-       d="m -9.7085407,6.4718866 0,2.2339767 1.7383266,0 0,6.0805907 -1.7383266,0 0,2.393546 4.1318731,0 0,-10.7081134 z"
-       id="path4245"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       style="fill:url(#linearGradient4267);fill-opacity:1"
-       inkscape:connector-curvature="0"
-       d="m -9.7085407,5.4849741 0,2.2339767 1.7383266,0 0,6.0805912 -1.7383266,0 0,2.393546 4.1318731,0 0,-10.7081139 z"
-       id="path4247"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4249"
-       d="m -9.7085407,5.4849741 0,2.2339767 1.7383266,0 0,6.0805912 -1.7383266,0 0,2.393546 4.1318731,0 0,-10.7081139 z"
-       inkscape:connector-curvature="0"
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1" />
-    <g
-       style="opacity:0.3;fill:none;stroke:none;stroke-width:1.08245623;stroke-miterlimit:4;stroke-dasharray:none"
-       id="g4588"
-       transform="matrix(0.45006852,0,0,0.45006852,-43.368966,-0.33294291)">
-      <g
-         style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-         transform="matrix(0.35454545,0,0,0.35454545,49.73436,4.4363587)"
-         id="g4590">
-        <g
-           style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-           id="g4592">
-          <path
-             id="path4594"
-             d="m 59,27 0,14 -17,0 0,32 17,0 0,15 -32,0 0,-61 32,0 z"
-             inkscape:connector-curvature="0"
-             style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none" />
-        </g>
-      </g>
-      <g
-         style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-         transform="matrix(0.35454545,0,0,0.35454545,49.73436,4.4363587)"
-         id="g4596">
-        <g
-           style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-           id="g4598">
-          <path
-             id="path4600"
-             d="m 99,27 0,61 -32,0 0,-15 18,0 0,-32 -18,0 0,-14 32,0 z"
-             inkscape:connector-curvature="0"
-             style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none" />
-        </g>
-      </g>
-    </g>
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4578"
-       d="m -12.154926,6.4718866 0,2.2339767 -1.738327,0 0,6.0805907 1.738327,0 0,2.393546 -4.131873,0 0,-10.7081134 z"
-       inkscape:connector-curvature="0"
-       style="opacity:0.3;fill:#333333;stroke:#333333;stroke-width:1" />
-    <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#004471;stroke-width:0.99999988;stroke-opacity:1;marker:none;enable-background:accumulate"
-       d="m -17.708995,3.2877006 13.5535829,0 c 0.4290672,0 0.7744901,0.345423 0.7744901,0.7744908 l 0,13.5535836 c 0,0.429067 -0.3454229,0.77449 -0.7744901,0.77449 l -13.5535829,0 c -0.429068,0 -0.774491,-0.345423 -0.774491,-0.77449 l 0,-13.5535836 c 0,-0.4290678 0.345423,-0.7744908 0.774491,-0.7744908 z"
-       id="path4629"
-       inkscape:connector-curvature="0" />
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4584"
-       d="m -12.154926,5.4849741 0,2.2339767 -1.738327,0 0,6.0805912 1.738327,0 0,2.393546 -4.131873,0 0,-10.7081139 z"
-       inkscape:connector-curvature="0"
-       style="fill:url(#linearGradient4620);fill-opacity:1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1"
-       inkscape:connector-curvature="0"
-       d="m -12.154926,5.4849741 0,2.2339767 -1.738327,0 0,6.0805912 1.738327,0 0,2.393546 -4.131873,0 0,-10.7081139 z"
-       id="path4602"
-       sodipodi:nodetypes="ccccccccc" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient4327);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="rect4325"
-       y="2.3389826"
-       x="-19.432205"
-       height="17"
-       width="17" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path4339"
-       d="m -15.789228,6.485 3.129547,0"
-       style="opacity:0.15;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       style="opacity:0.15;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m -9.2073777,6.485 3.1295471,0"
-       id="path4341"
-       inkscape:connector-curvature="0" />
-    <path
-       sodipodi:nodetypes="cc"
-       style="opacity:0.15;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4370);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m -15.287,6.985 0,8.692048"
-       id="path4362"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path4372"
-       d="m -6.5778306,6.985 0,8.692048"
-       style="opacity:0.15;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4374);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       sodipodi:nodetypes="cc" />
-  </g>
+  <rect
+     width="19.000002"
+     height="19.000002"
+     rx="1"
+     ry="1"
+     x="2.499999"
+     y="2.5000331"
+     id="rect5505-21-8"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5521-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <rect
+     width="17"
+     height="17"
+     x="3.5"
+     y="3.4987667"
+     id="rect6741-9"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient5397-6);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     width="19.000002"
+     height="19.000002"
+     rx="1"
+     ry="1"
+     x="2.499999"
+     y="2.5000331"
+     id="rect5505-21-8-1"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#004264;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fefefe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     d="m 5.7179491,4.9999999 12.5641029,0 C 18.679795,4.9999999 19,5.3202053 19,5.7179489 L 19,18.282052 C 19,18.679795 18.679795,19 18.282052,19 L 5.7179492,19 C 5.3202054,19 5,18.679795 5,18.282052 L 5,5.7179489 C 5,5.3202053 5.3202054,4.9999999 5.7179492,4.9999999 Z"
+     id="rect4572"
+     inkscape:connector-curvature="0" />
+  <path
+     style="opacity:0.07;fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+     inkscape:connector-curvature="0"
+     d="m 11,8 0,2 -2,0 0,6 2,0 0,2 -4,0 0,-10 z"
+     id="path4584-9-6-1"
+     sodipodi:nodetypes="ccccccccc" />
+  <path
+     style="opacity:0.15;fill:#000000;fill-opacity:1"
+     inkscape:connector-curvature="0"
+     d="m 11,8 0,2 -2,0 0,6 2,0 0,2 -4,0 0,-10 z"
+     id="path4584-9-6"
+     sodipodi:nodetypes="ccccccccc" />
+  <path
+     style="fill:url(#linearGradient4620-3);fill-opacity:1"
+     inkscape:connector-curvature="0"
+     d="m 11,7 0,2 -2,0 0,6 2,0 0,2 -4,0 0,-10 z"
+     id="path4584-9"
+     sodipodi:nodetypes="ccccccccc" />
+  <path
+     style="opacity:0.07000002;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     d="M 13,8.0000002 13,10 l 2,0 0,6 -2,0 0,2 4,0 0,-9.9999998 z"
+     id="path4584-9-6-1-2"
+     sodipodi:nodetypes="ccccccccc" />
+  <path
+     style="opacity:0.15;fill:#000000;fill-opacity:1"
+     inkscape:connector-curvature="0"
+     d="M 13,8.0000002 13,10 l 2,0 0,6 -2,0 0,2 4,0 0,-9.9999998 z"
+     id="path4584-9-6-0"
+     sodipodi:nodetypes="ccccccccc" />
+  <path
+     style="fill:url(#linearGradient4620-3-0);fill-opacity:1"
+     inkscape:connector-curvature="0"
+     d="m 13,7.0000002 0,2 2,0 L 15,15 l -2,0 0,2 4,0 0,-9.9999998 z"
+     id="path4584-9-61"
+     sodipodi:nodetypes="ccccccccc" />
 </svg>

--- a/elementaryPlus/apps/32/brackets.svg
+++ b/elementaryPlus/apps/32/brackets.svg
@@ -14,7 +14,7 @@
    width="32"
    height="32"
    id="svg6860"
-   inkscape:version="0.48+devel r"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="brackets.svg">
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -25,19 +25,33 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1025"
+     inkscape:window-width="1280"
+     inkscape:window-height="744"
      id="namedview46"
      showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="7.9676993"
-     inkscape:cy="12.580768"
+     inkscape:zoom="18.90625"
+     inkscape:cx="1.2429752"
+     inkscape:cy="16"
      inkscape:window-x="0"
      inkscape:window-y="30"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg6860" />
+     inkscape:current-layer="svg6860"
+     inkscape:snap-midpoints="true"
+     inkscape:object-nodes="true" />
   <defs
      id="defs6862">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3778">
+      <stop
+         style="stop-color:#3c3c3c;stop-opacity:1"
+         offset="0"
+         id="stop3780" />
+      <stop
+         style="stop-color:#505050;stop-opacity:1"
+         offset="1"
+         id="stop3782" />
+    </linearGradient>
     <linearGradient
        x1="167.98311"
        y1="8.50811"
@@ -181,38 +195,17 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4552"
-       id="linearGradient4620"
-       gradientUnits="userSpaceOnUse"
-       x1="20.375"
-       y1="34.5625"
-       x2="20.375"
-       y2="15.25"
-       gradientTransform="matrix(0.64102564,0,0,0.64102564,-32.350725,0.97436312)" />
-    <linearGradient
        id="linearGradient4552"
        inkscape:collect="always">
       <stop
          id="stop4554"
          offset="0"
-         style="stop-color:#333333;stop-opacity:1" />
+         style="stop-color:#3c3c3c;stop-opacity:1" />
       <stop
          id="stop4556"
          offset="1"
-         style="stop-color:#4d4d4d;stop-opacity:1" />
+         style="stop-color:#505050;stop-opacity:1" />
     </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-1"
-       id="radialGradient4616"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,6.0881745,-7.4743333,0,57.989369,-49.769854)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
-       fy="9.9571075"
-       r="12.671875" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-1">
       <stop
@@ -232,44 +225,122 @@
          style="stop-color:#0274bd;stop-opacity:1"
          offset="1" />
     </linearGradient>
+    <radialGradient
+       cx="7.8500957"
+       cy="9.9571075"
+       r="12.671875"
+       fx="7.3198657"
+       fy="9.9571075"
+       id="radialGradient5521-1-50"
+       xlink:href="#linearGradient4457"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.918619,-11.65996,0,176.43052,-67.586719)" />
+    <linearGradient
+       id="linearGradient4457">
+      <stop
+         id="stop4459"
+         style="stop-color:#90dbec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4461"
+         style="stop-color:#42baea;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop4463"
+         style="stop-color:#4392e9;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop4465"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-6"
+       id="radialGradient2976-9"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-6"
+       id="radialGradient2978-7"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       cx="7.8500957"
+       cy="9.9571075"
+       r="12.671875"
+       fx="7.3198657"
+       fy="9.9571075"
+       id="radialGradient5521-1"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,4.0975054,-8.0722799,0,96.951904,-38.319653)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         id="stop3750-8-9" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#42baea;stop-opacity:1"
+         id="stop3752-3-2" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#4299ea;stop-opacity:1"
+         id="stop3754-7-2" />
+      <stop
+         offset="1"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         id="stop3756-9-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.67567574,0,0,0.67567574,-0.216217,-0.21620543)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924-0"
+       id="linearGradient4161-6"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4552"
-       id="linearGradient4272"
+       xlink:href="#linearGradient3702-501-757-3"
+       id="linearGradient3921"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3778"
+       id="linearGradient4272-9"
        gradientUnits="userSpaceOnUse"
        x1="20.375"
        y1="34.5625"
        x2="20.375"
        y2="15.25"
-       gradientTransform="matrix(-0.64102564,0,0,0.64102564,-1.5802416,0.97436312)" />
+       gradientTransform="matrix(0.64102564,0,0,0.64102564,0.224223,-0.0705128)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3924-0"
-       id="linearGradient4380"
-       x1="-18.5625"
-       y1="4.9375"
-       x2="-18.5625"
-       y2="29.125"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3924-0"
-       id="linearGradient4397"
-       x1="-21.831923"
-       y1="10.344854"
-       x2="-21.831923"
-       y2="23.647301"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3924-0"
-       id="linearGradient4401"
+       xlink:href="#linearGradient4552"
+       id="linearGradient4272-9-8"
        gradientUnits="userSpaceOnUse"
-       x1="-21.831923"
-       y1="10.344854"
-       x2="-21.831923"
-       y2="23.647301"
-       gradientTransform="matrix(-1,0,0,1,-33.930651,0)" />
+       x1="20.375"
+       y1="34.5625"
+       x2="20.375"
+       y2="15.25"
+       gradientTransform="matrix(-0.64102564,0,0,0.64102564,31.775777,-0.070513)" />
   </defs>
   <metadata
      id="metadata6865">
@@ -279,171 +350,118 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="display:inline"
-     id="g2036-2"
-     transform="matrix(0.6999997,0,0,0.3333336,-0.8000002,15.33333)">
+     transform="matrix(0.6999997,0,0,0.3333336,-0.8,15.33333)"
+     id="g2036-2-7"
+     style="display:inline">
     <g
-       style="opacity:0.4"
-       id="g3712-3"
-       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712-3-9"
+       style="opacity:0.4">
       <rect
-         style="fill:url(#radialGradient2976);fill-opacity:1;stroke:none"
-         id="rect2801-0"
-         y="40"
+         width="5"
+         height="7"
          x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient2978);fill-opacity:1;stroke:none"
-         id="rect3696-2"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient2980);fill-opacity:1;stroke:none"
-         id="rect3700-1"
          y="40"
-         x="10"
+         id="rect2801-0-2"
+         style="fill:url(#radialGradient2976-9);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1,-1)"
+         id="rect3696-2-0"
+         style="fill:url(#radialGradient2978-7);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
          height="7.0000005"
-         width="28" />
+         x="10"
+         y="40"
+         id="rect3700-1-2"
+         style="fill:url(#linearGradient3921);fill-opacity:1;stroke:none" />
     </g>
   </g>
-  <g
-     id="g4403"
-     transform="translate(32.966102,0)">
-    <rect
-       width="25"
-       height="25"
-       rx="1.2820513"
-       ry="1.2820513"
-       x="-29.466103"
-       y="4.5"
-       id="rect4566"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4616);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
-    <rect
-       width="25"
-       height="25"
-       rx="1.2820513"
-       ry="1.2820513"
-       x="-29.466103"
-       y="4.5"
-       id="rect4570"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#004471;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <path
-       inkscape:connector-curvature="0"
-       id="rect4572"
-       d="m -25.882933,7.0641029 17.8336619,0 c 0.5645622,0 1.0190661,0.4545044 1.0190661,1.0190673 l 0,17.8336618 c 0,0.564562 -0.4545039,1.019066 -1.0190661,1.019066 l -17.8336619,0 c -0.564562,0 -1.019067,-0.454504 -1.019067,-1.019066 l 0,-17.8336618 c 0,-0.5645629 0.454505,-1.0190673 1.019067,-1.0190673 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fefefe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
-    <g
-       id="g4361">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m -15.855469,10.996156 0,0.5 0,3.439453 2.28711,0 0,7.001953 -2.28711,0 0,4.148438 6.4355471,0 0,-15.089844 z"
-         id="path4353"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m -24.511719,10.996156 0,15.089844 6.4375,0 0,-4.148438 -2.287109,0 0,-7.001953 2.287109,0 0,-3.939453 -0.5,0 z"
-         id="path4355"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
-    </g>
-    <path
-       style="opacity:0.3;fill:#333333;stroke:#333333;stroke-width:0.99999994"
-       inkscape:connector-curvature="0"
-       d="m -15.356019,10.996376 0,2.939443 2.287272,0 0,8.000778 -2.287272,0 0,3.149403 5.4366748,0 0,-14.089624 z"
-       id="path4245"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       style="fill:url(#linearGradient4272);fill-opacity:1"
-       inkscape:connector-curvature="0"
-       d="m -15.356019,9.9552528 0,2.9394432 2.287272,0 0,8.000777 -2.287272,0 0,3.149403 5.4366748,0 0,-14.0896232 z"
-       id="path4247"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4249"
-       d="m -15.356019,9.9552528 0,2.9394432 2.287272,0 0,8.000777 -2.287272,0 0,3.149403 5.4366748,0 0,-14.0896232 z"
-       inkscape:connector-curvature="0"
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99999994" />
-    <g
-       style="opacity:0.3;fill:none;stroke:none;stroke-width:1.08245623;stroke-miterlimit:4;stroke-dasharray:none"
-       id="g4588"
-       transform="matrix(0.59219542,0,0,0.59219542,-59.646052,2.3000984)">
-      <g
-         style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-         transform="matrix(0.35454545,0,0,0.35454545,49.73436,4.4363587)"
-         id="g4590">
-        <g
-           style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-           id="g4592">
-          <path
-             id="path4594"
-             d="m 59,27 0,14 -17,0 0,32 17,0 0,15 -32,0 0,-61 32,0 z"
-             inkscape:connector-curvature="0"
-             style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none" />
-        </g>
-      </g>
-      <g
-         style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-         transform="matrix(0.35454545,0,0,0.35454545,49.73436,4.4363587)"
-         id="g4596">
-        <g
-           style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-           id="g4598">
-          <path
-             id="path4600"
-             d="m 99,27 0,61 -32,0 0,-15 18,0 0,-32 -18,0 0,-14 32,0 z"
-             inkscape:connector-curvature="0"
-             style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none" />
-        </g>
-      </g>
-    </g>
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4578"
-       d="m -18.574947,10.996376 0,2.939443 -2.287272,0 0,8.000778 2.287272,0 0,3.149403 -5.436675,0 0,-14.089624 z"
-       inkscape:connector-curvature="0"
-       style="opacity:0.3;fill:#333333;stroke:#333333;stroke-width:0.99999994" />
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4584"
-       d="m -18.574947,9.9552528 0,2.9394432 -2.287272,0 0,8.000777 2.287272,0 0,3.149403 -5.436675,0 0,-14.0896232 z"
-       inkscape:connector-curvature="0"
-       style="fill:url(#linearGradient4620);fill-opacity:1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99999994"
-       inkscape:connector-curvature="0"
-       d="m -18.574947,9.9552528 0,2.9394432 -2.287272,0 0,8.000777 2.287272,0 0,3.149403 -5.436675,0 0,-14.0896232 z"
-       id="path4602"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#004471;stroke-width:0.99999994;stroke-opacity:1;marker:none;enable-background:accumulate"
-       d="m -25.882933,7.0641029 17.8336619,0 c 0.5645622,0 1.0190661,0.4545044 1.0190661,1.0190673 l 0,17.8336618 c 0,0.564562 -0.4545039,1.019066 -1.0190661,1.019066 l -17.8336619,0 c -0.564562,0 -1.019067,-0.454504 -1.019067,-1.019066 l 0,-17.8336618 c 0,-0.5645629 0.454505,-1.0190673 1.019067,-1.0190673 z"
-       id="path4629"
-       inkscape:connector-curvature="0" />
-    <path
-       id="rect4365"
-       d="m -28.183594,5.5 c -0.173553,0 -0.283203,0.1076963 -0.283203,0.28125 l 0,22.4375 c 0,0.173554 0.10965,0.28125 0.283203,0.28125 l 22.4355471,0 c 0.1735537,0 0.28125,-0.107696 0.28125,-0.28125 l 0,-22.4375 c 0,-0.1735537 -0.1076963,-0.28125 -0.28125,-0.28125 l -22.4355471,0 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4380);stroke-width:0.99999994;marker:none;enable-background:accumulate"
-       inkscape:connector-curvature="0" />
-    <path
-       id="path4382"
-       d="m -23.011719,10.955078 0,12.089844 3.4375,0 0,-1.150391 -2.287109,0 0,-10 2.287109,0 0,-0.939453 -3.4375,0 z"
-       style="opacity:0.5;fill:none;fill-opacity:1;stroke:url(#linearGradient4397)"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:connector-curvature="0"
-       style="opacity:0.5;fill:none;fill-opacity:1;stroke:url(#linearGradient4401)"
-       d="m -10.918932,10.955078 0,12.089844 -3.4375,0 0,-1.150391 2.287109,0 0,-10 -2.287109,0 0,-0.939453 3.4375,0 z"
-       id="path4399" />
-  </g>
+  <rect
+     width="27"
+     height="27"
+     rx="2.1600001"
+     ry="2.1600001"
+     x="2.5"
+     y="2.5000007"
+     id="rect5505"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5521-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <rect
+     width="25"
+     height="25"
+     rx="1.0869565"
+     ry="1.0869565"
+     x="3.5"
+     y="3.5000017"
+     id="rect6741-7-4"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient4161-6);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     width="27"
+     height="27"
+     rx="2.1600001"
+     ry="2.1600001"
+     x="2.5"
+     y="2.5000007"
+     id="rect5505-6"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#004264;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.07000002;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="M 7.0256411,7 24.974359,7 C 25.542564,7 26,7.457436 26,8.025642 l 0,17.948717 C 26,26.542564 25.542564,27 24.974359,27 L 7.0256411,27 C 6.4574372,27 5.9999999,26.542564 5.9999999,25.974359 l 0,-17.948717 C 5.9999999,7.457436 6.4574372,7 7.0256411,7 Z"
+     id="rect4572-37-5"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     d="m 7.0256417,7.0000001 17.9487173,0 C 25.542564,7.0000001 26,7.457436 26,8.025642 l 0,17.948717 C 26,26.542564 25.542564,27 24.974359,27 L 7.0256417,27 C 6.4574374,27 6.0000001,26.542564 6.0000001,25.974359 l 0,-17.948717 c 0,-0.568206 0.4574373,-1.0256419 1.0256416,-1.0256419 z"
+     id="rect4572-37"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fefefe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     d="m 7.0256416,6.0000003 17.9487174,0 C 25.542564,6.0000003 26,6.4574366 26,7.0256419 L 26,24.974359 C 26,25.542564 25.542564,26 24.974359,26 L 7.0256416,26 C 6.4574373,26 6,25.542564 6,24.974359 L 6,7.0256419 C 6,6.4574366 6.4574373,6.0000003 7.0256416,6.0000003 Z"
+     id="rect4572"
+     inkscape:connector-curvature="0" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-8-6-1"
+     d="m 15,10 0,3 -3,0 0,8 3,0 0,3 -6,0 0,-14 z"
+     inkscape:connector-curvature="0"
+     style="opacity:0.07000002;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-8-6"
+     d="m 15,10 0,3 -3,0 0,8 3,0 0,3 -6,0 0,-14 z"
+     inkscape:connector-curvature="0"
+     style="opacity:0.15;fill:#000000;fill-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-8"
+     d="m 15,9 0,3 -3,0 0,8 3,0 0,3 -6,0 0,-14 z"
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient4272-9);fill-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-8-6-1-0"
+     d="m 17,10 0,3 3,0 0,8 -3,0 0,3 6,0 0,-14 z"
+     inkscape:connector-curvature="0"
+     style="opacity:0.07000002;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-8-6-3"
+     d="m 17,10 0,3 3,0 0,8 -3,0 0,3 6,0 0,-14 z"
+     inkscape:connector-curvature="0"
+     style="opacity:0.15;fill:#000000;fill-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-8-61"
+     d="m 17,9 0,3 3,0 0,8 -3,0 0,3 6,0 0,-14 z"
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient4272-9-8);fill-opacity:1" />
 </svg>

--- a/elementaryPlus/apps/48/brackets.svg
+++ b/elementaryPlus/apps/48/brackets.svg
@@ -14,7 +14,7 @@
    width="48"
    height="48"
    id="svg6649"
-   inkscape:version="0.48+devel r"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="brackets.svg"
    inkscape:export-filename="/home/francisco/Documents/brackets.png"
    inkscape:export-xdpi="90"
@@ -28,32 +28,86 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1025"
+     inkscape:window-width="1280"
+     inkscape:window-height="744"
      id="namedview108"
      showgrid="false"
      showguides="true"
      inkscape:guide-bbox="true"
-     inkscape:zoom="1"
-     inkscape:cx="20.678616"
-     inkscape:cy="19.207734"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="-20.495843"
+     inkscape:cy="15.04782"
      inkscape:window-x="0"
      inkscape:window-y="30"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg6649" />
+     inkscape:current-layer="svg6649"
+     inkscape:object-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:showpageshadow="true"
+     showborder="true" />
   <defs
      id="defs6651">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3786">
+      <stop
+         style="stop-color:#3c3c3c;stop-opacity:1"
+         offset="0"
+         id="stop3788" />
+      <stop
+         style="stop-color:#505050;stop-opacity:1"
+         offset="1"
+         id="stop3790" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3781">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         id="stop3783" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#42baea;stop-opacity:1"
+         id="stop3785" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#4299ea;stop-opacity:1"
+         id="stop3787" />
+      <stop
+         offset="1"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         id="stop3789" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4457">
+      <stop
+         id="stop4459"
+         style="stop-color:#90dbec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4461"
+         style="stop-color:#42baea;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop4463"
+         style="stop-color:#4392e9;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop4465"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
     <linearGradient
        id="linearGradient4552"
        inkscape:collect="always">
       <stop
          id="stop4554"
          offset="0"
-         style="stop-color:#333333;stop-opacity:1" />
+         style="stop-color:#3c3c3c;stop-opacity:1" />
       <stop
          id="stop4556"
          offset="1"
-         style="stop-color:#4d4d4d;stop-opacity:1" />
+         style="stop-color:#505050;stop-opacity:1" />
     </linearGradient>
     <linearGradient
        x1="23.99999"
@@ -177,48 +231,6 @@
        id="linearGradient6647"
        xlink:href="#linearGradient3702-501-757"
        gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient4610"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient4612"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient4614"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
-       id="radialGradient4616"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,9.4975523,-11.65996,0,140.93055,-79.160978)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
-       fy="9.9571075"
-       r="12.671875" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient3924-1"
@@ -231,42 +243,198 @@
        y2="43" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4552"
+       xlink:href="#linearGradient3786"
        id="linearGradient4620"
        gradientUnits="userSpaceOnUse"
        x1="20.375"
        y1="34.5625"
        x2="20.375"
-       y2="15.25" />
+       y2="15.25"
+       gradientTransform="matrix(1.0022151,0,0,1.0009185,-0.03781637,-1.0230561)" />
     <linearGradient
-       inkscape:collect="always"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3058-3"
        xlink:href="#linearGradient3924-1"
-       id="linearGradient4624"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-50.44965,0.17737223)"
-       x1="68.5"
-       y1="13.375"
-       x2="68.5"
-       y2="36.125" />
+       gradientTransform="translate(-49.632625,-2.2576121)" />
+    <radialGradient
+       cx="7.8500957"
+       cy="9.9571075"
+       r="12.671875"
+       fx="7.3198657"
+       fy="9.9571075"
+       id="radialGradient5521-1-5"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.918619,-11.65996,0,91.297921,-56.719344)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         id="stop3750-8-9" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#42baea;stop-opacity:1"
+         id="stop3752-3-2" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3689e6;stop-opacity:1"
+         id="stop3754-7-2" />
+      <stop
+         offset="1"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         id="stop3756-9-3" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-6"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-1"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3058-9"
+       xlink:href="#linearGradient3924-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-74.381363,-10.035786)" />
+    <radialGradient
+       cx="7.8500957"
+       cy="9.9571075"
+       r="12.671875"
+       fx="7.3198657"
+       fy="9.9571075"
+       id="radialGradient5521-1-50"
+       xlink:href="#linearGradient3781"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.918619,-11.65996,0,140.93053,-53.461722)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-63"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-6"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <radialGradient
+       cx="7.8500957"
+       cy="9.9571075"
+       r="12.671875"
+       fx="7.3198657"
+       fy="9.9571075"
+       id="radialGradient5521-1-50-6"
+       xlink:href="#linearGradient4457"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.918619,-11.65996,0,201.43052,-52.961724)" />
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3058-36"
+       xlink:href="#linearGradient3924-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-50.000014,1.000006)" />
+    <radialGradient
+       cx="7.8500957"
+       cy="9.9571075"
+       r="12.671875"
+       fx="7.3198657"
+       fy="9.9571075"
+       id="radialGradient5521-1-6"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.918619,-11.65996,0,90.930526,-53.461724)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-7"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-3"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-7-8"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-3-2"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient6647-0"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4552"
-       id="linearGradient4253"
+       id="linearGradient4620-5"
        gradientUnits="userSpaceOnUse"
        x1="20.375"
        y1="34.5625"
        x2="20.375"
-       y2="15.25" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3924-1"
-       id="linearGradient4255"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-50.44965,0.17737223)"
-       x1="68.5"
-       y1="13.375"
-       x2="68.5"
-       y2="36.125" />
+       y2="15.25"
+       gradientTransform="matrix(-1.0022151,0,0,1.0009185,48.037816,-1.023056)" />
   </defs>
   <metadata
      id="metadata6654">
@@ -281,40 +449,37 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="g22"
-     transform="translate(-137.22034,-35.542372)" />
-  <g
      style="opacity:0.6"
-     id="g4558"
-     transform="matrix(1.1578952,0,0,0.6428571,-3.789476,16.035716)">
+     id="g3712-5-5"
+     transform="matrix(1.1578952,0,0,0.6428571,-3.7894848,16.285716)">
     <rect
-       style="fill:url(#radialGradient4610);fill-opacity:1;stroke:none"
-       id="rect4560"
+       style="fill:url(#radialGradient3013-7-8);fill-opacity:1;stroke:none"
+       id="rect2801-3-9"
        y="40"
        x="38"
        height="7"
        width="5" />
     <rect
-       style="fill:url(#radialGradient4612);fill-opacity:1;stroke:none"
-       id="rect4562"
+       style="fill:url(#radialGradient3015-3-2);fill-opacity:1;stroke:none"
+       id="rect3696-6-2"
        transform="scale(-1,-1)"
        y="-47"
        x="-10"
        height="7"
        width="5" />
     <rect
-       style="fill:url(#linearGradient4614);fill-opacity:1;stroke:none"
-       id="rect4564"
+       style="fill:url(#linearGradient6647-0);fill-opacity:1;stroke:none"
+       id="rect3700-4-2"
        y="40"
        x="10"
        height="7.0000005"
        width="28" />
   </g>
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4616);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
-     id="rect4566"
-     y="5.4999948"
-     x="4.5000114"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient5521-1-50);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="5.5"
+     x="4.5"
      ry="2"
      rx="2"
      height="39"
@@ -328,6 +493,45 @@
      rx="1"
      height="37"
      width="37" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.05;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 10.511364,10 C 9.132476,10 8,11.132475 8,12.511364 L 8,39.488636 C 8,40.867525 9.132476,42 10.511364,42 l 26.977272,0 C 38.867524,42 40,40.867524 40,39.488636 L 40,12.511364 C 40,11.132475 38.867524,10 37.488636,10 l -26.977272,0 z"
+     id="path4016"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     d="m 10.538461,11 26.923078,0 C 38.313846,11 39,11.686155 39,12.538463 l 0,26.923076 C 39,40.313846 38.313846,41 37.461539,41 L 10.538461,41 C 9.686155,41 9,40.313846 9,39.461539 L 9,12.538463 C 9,11.686155 9.686155,11 10.538461,11 Z"
+     id="rect4572-6"
+     inkscape:connector-curvature="0" />
+  <path
+     sodipodi:nodetypes="sssssssss"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fefefe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     d="m 10.538462,9.999513 26.923077,0 c 0.852307,0 1.538461,0.7083 1.538461,1.588115 l 0,26.823771 c 0,0.879814 -0.686154,1.588114 -1.538461,1.588114 l -26.923077,0 C 9.6861552,39.999513 9,39.291213 9,38.411399 L 9,11.587628 C 9,10.707813 9.6861552,9.999513 10.538462,9.999513 Z"
+     id="rect4572"
+     inkscape:connector-curvature="0" />
+  <path
+     style="opacity:0.07000002;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     d="m 22,15 0,5 -4,0 0,12.000001 4,-10e-7 0,5 -9,0 0,-22 z"
+     id="path4584-1-36"
+     sodipodi:nodetypes="ccccccccc" />
+  <path
+     id="path4594"
+     d="m 22.689864,14.510089 0,4.585531 -5.568144,0 0,10.481213 5.568144,0 0,4.913068 -10.481213,0 0,-19.979812 10.481213,0 z"
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none" />
+  <path
+     style="opacity:0.15;fill:#000000;fill-opacity:1;stroke:none"
+     inkscape:connector-curvature="0"
+     d="m 22,15 0,5 -4,0 0,12.000001 4,-10e-7 0,5 -9,0 0,-22 z"
+     id="path4584-1"
+     sodipodi:nodetypes="ccccccccc" />
+  <path
+     style="fill:url(#linearGradient4620);fill-opacity:1;stroke:none"
+     inkscape:connector-curvature="0"
+     d="m 22,14 0,5 -4,0 0,12 4,0 0,5 -9,0 0,-22 z"
+     id="path4584"
+     sodipodi:nodetypes="ccccccccc" />
   <rect
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#004471;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4570"
@@ -338,113 +542,26 @@
      height="39"
      width="39" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fefefe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
-     d="m 10.089755,9.4999947 27.820513,0 c 0.880717,0 1.589743,0.7090263 1.589743,1.5897443 l 0,27.820513 c 0,0.880717 -0.709026,1.589743 -1.589743,1.589743 l -27.820513,0 c -0.880717,0 -1.589744,-0.709026 -1.589744,-1.589743 l 0,-27.820513 c 0,-0.880718 0.709027,-1.5897443 1.589744,-1.5897443 z"
-     id="rect4572"
-     inkscape:connector-curvature="0" />
-  <g
-     id="g4241"
-     transform="matrix(-1,0,0,1,48.001954,0)">
-    <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
-       id="path4243"
-       d="m 12.509766,15.009532 0,22.980468 9.480468,0 0,-5.914062 -4.568359,0 0,-11.480469 4.568359,0 0,-5.585937 -0.5,0 z"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    <path
-       style="opacity:0.3;fill:#333333;stroke:#333333"
-       inkscape:connector-curvature="0"
-       d="m 21.490213,15.010188 0,4.585531 -3.568144,0 0,12.481213 3.568144,0 0,4.913068 -8.481213,0 0,-21.979812 z"
-       id="path4245"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       style="fill:url(#linearGradient4253);fill-opacity:1"
-       inkscape:connector-curvature="0"
-       d="m 21.490213,14.010188 0,4.585531 -3.568144,0 0,12.481213 3.568144,0 0,4.913068 -8.481213,0 0,-21.979812 z"
-       id="path4247"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4249"
-       d="m 21.490213,14.010188 0,4.585531 -3.568144,0 0,12.481213 3.568144,0 0,4.913068 -8.481213,0 0,-21.979812 z"
-       inkscape:connector-curvature="0"
-       style="opacity:0.3;fill:none;stroke:#000000" />
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4251"
-       d="m 14.009336,15.009403 0,19.980469 6.480469,0 0,-2.912109 -3.568359,0 0,-14.482422 3.568359,0 0,-2.585938 z"
-       style="opacity:0.5;fill:none;fill-opacity:1;stroke:url(#linearGradient4255)"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     transform="matrix(0.92382486,0,0,0.92382486,-42.58071,2.0681476)"
-     id="g4588"
-     style="opacity:0.3;fill:none;stroke:none;stroke-width:1.08245623;stroke-miterlimit:4;stroke-dasharray:none">
-    <g
-       id="g4590"
-       transform="matrix(0.35454545,0,0,0.35454545,49.73436,4.4363587)"
-       style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none">
-      <g
-         id="g4592"
-         style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none">
-        <path
-           style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           d="m 59,27 0,14 -17,0 0,32 17,0 0,15 -32,0 0,-61 32,0 z"
-           id="path4594" />
-      </g>
-    </g>
-    <g
-       id="g4596"
-       transform="matrix(0.35454545,0,0,0.35454545,49.73436,4.4363587)"
-       style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none">
-      <g
-         id="g4598"
-         style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none">
-        <path
-           style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           d="m 99,27 0,61 -32,0 0,-15 18,0 0,-32 -18,0 0,-14 32,0 z"
-           id="path4600" />
-      </g>
-    </g>
-  </g>
-  <g
-     id="g4234">
-    <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       d="m 12.509766,15.009532 0,22.980468 9.480468,0 0,-5.914062 -4.568359,0 0,-11.480469 4.568359,0 0,-5.585937 -0.5,0 z"
-       id="path4574"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4578"
-       d="m 21.490213,15.010188 0,4.585531 -3.568144,0 0,12.481213 3.568144,0 0,4.913068 -8.481213,0 0,-21.979812 z"
-       inkscape:connector-curvature="0"
-       style="opacity:0.3;fill:#333333;stroke:#333333" />
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4584"
-       d="m 21.490213,14.010188 0,4.585531 -3.568144,0 0,12.481213 3.568144,0 0,4.913068 -8.481213,0 0,-21.979812 z"
-       inkscape:connector-curvature="0"
-       style="fill:url(#linearGradient4620);fill-opacity:1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#000000"
-       inkscape:connector-curvature="0"
-       d="m 21.490213,14.010188 0,4.585531 -3.568144,0 0,12.481213 3.568144,0 0,4.913068 -8.481213,0 0,-21.979812 z"
-       id="path4602"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       inkscape:connector-curvature="0"
-       style="opacity:0.5;fill:none;fill-opacity:1;stroke:url(#linearGradient4624)"
-       d="m 14.009336,15.009403 0,19.980469 6.480469,0 0,-2.912109 -3.568359,0 0,-14.482422 3.568359,0 0,-2.585938 z"
-       id="path4606"
-       sodipodi:nodetypes="ccccccccc" />
-  </g>
-  <path
+     style="opacity:0.07000002;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      inkscape:connector-curvature="0"
-     id="path4629"
-     d="m 10.089755,9.4999947 27.820513,0 c 0.880717,0 1.589743,0.7090263 1.589743,1.5897443 l 0,27.820513 c 0,0.880717 -0.709026,1.589743 -1.589743,1.589743 l -27.820513,0 c -0.880717,0 -1.589744,-0.709026 -1.589744,-1.589743 l 0,-27.820513 c 0,-0.880718 0.709027,-1.5897443 1.589744,-1.5897443 z"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#004471;stroke-width:0.99999994;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 26,15 0,5 4,0 0,12.000001 -4,-10e-7 0,5 9,0 0,-22 z"
+     id="path4584-1-36-6"
+     sodipodi:nodetypes="ccccccccc" />
+  <path
+     id="path4594-2"
+     d="m 25.310136,14.510089 0,4.585531 5.568144,0 0,10.481213 -5.568144,0 0,4.913068 10.481213,0 0,-19.979812 -10.481213,0 z"
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none" />
+  <path
+     style="opacity:0.15;fill:#000000;fill-opacity:1;stroke:none"
+     inkscape:connector-curvature="0"
+     d="m 26,15 0,5 4,0 0,12.000001 -4,-10e-7 0,5 9,0 0,-22 z"
+     id="path4584-1-9"
+     sodipodi:nodetypes="ccccccccc" />
+  <path
+     style="fill:url(#linearGradient4620-5);fill-opacity:1;stroke:none"
+     inkscape:connector-curvature="0"
+     d="m 26,14 0,5 4,0 0,12 -4,0 0,5 9,0 0,-22 z"
+     id="path4584-12"
+     sodipodi:nodetypes="ccccccccc" />
 </svg>

--- a/elementaryPlus/apps/64/brackets.svg
+++ b/elementaryPlus/apps/64/brackets.svg
@@ -14,7 +14,7 @@
    width="64"
    height="64"
    id="svg6333"
-   inkscape:version="0.48+devel r"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="brackets.svg">
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -25,19 +25,53 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1025"
+     inkscape:window-width="1280"
+     inkscape:window-height="744"
      id="namedview49"
      showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="24.89752"
-     inkscape:cy="23.783432"
+     inkscape:zoom="10.521739"
+     inkscape:cx="32.000054"
+     inkscape:cy="31.249999"
      inkscape:window-x="0"
      inkscape:window-y="30"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg6333" />
+     inkscape:current-layer="svg6333"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true" />
   <defs
      id="defs6335">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3828">
+      <stop
+         style="stop-color:#3c3c3c;stop-opacity:1"
+         offset="0"
+         id="stop3830" />
+      <stop
+         style="stop-color:#505050;stop-opacity:1"
+         offset="1"
+         id="stop3832" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3996">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         id="stop3998" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#42baea;stop-opacity:1"
+         id="stop4000" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#4299ea;stop-opacity:1"
+         id="stop4002" />
+      <stop
+         offset="1"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         id="stop4004" />
+    </linearGradient>
     <linearGradient
        x1="167.98311"
        y1="8.50811"
@@ -144,7 +178,7 @@
        id="radialGradient3337-2-2"
        xlink:href="#linearGradient3688-166-749-4-0-3-8"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+       gradientTransform="matrix(3.1638751,0,0,0.99999998,38.297112,15.500001)" />
     <linearGradient
        id="linearGradient3688-166-749-4-0-3-8">
       <stop
@@ -165,7 +199,7 @@
        id="radialGradient3339-1-4"
        xlink:href="#linearGradient3688-464-309-9-2-4-2"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+       gradientTransform="matrix(3.1638751,0,0,0.99999998,-25.702995,-102.5)" />
     <linearGradient
        id="linearGradient3688-464-309-9-2-4-2">
       <stop
@@ -199,7 +233,8 @@
        y2="39.999443"
        id="linearGradient6394"
        xlink:href="#linearGradient3702-501-757-8-4-1-1"
-       gradientUnits="userSpaceOnUse" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5789502,0,0,0.7142857,-5.894751,27.928572)" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2">
       <stop
@@ -225,22 +260,12 @@
       <stop
          id="stop4554"
          offset="0"
-         style="stop-color:#333333;stop-opacity:1" />
+         style="stop-color:#3c3c3c;stop-opacity:1" />
       <stop
          id="stop4556"
          offset="1"
-         style="stop-color:#4d4d4d;stop-opacity:1" />
+         style="stop-color:#505050;stop-opacity:1" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4552"
-       id="linearGradient4620-0"
-       gradientUnits="userSpaceOnUse"
-       x1="20.375"
-       y1="35.816006"
-       x2="20.375"
-       y2="13.996492"
-       gradientTransform="matrix(1.4102564,0,0,1.4102564,-65.023206,-3.2564066)" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4552"
@@ -250,47 +275,124 @@
        y1="35.816006"
        x2="20.375"
        y2="13.745791"
-       gradientTransform="matrix(-1.4102564,0,0,1.4102564,2.6718584,-3.2564066)" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2"
-       id="radialGradient4616-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,13.393984,-16.443533,0,133.72501,-114.89369)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
-       fy="9.9571075"
-       r="12.671875" />
+       gradientTransform="matrix(-1.5327996,0,0,1.4102564,67.482365,-3.2564066)" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient3924-2-2-5-8"
        id="linearGradient4396"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(2.6882053,1.91e-6)"
+       gradientTransform="translate(65.865232,1.91e-6)"
        x1="-32.790581"
        y1="4.8427277"
        x2="-32.790581"
        y2="59.206055" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient4527"
-       x1="-40.305088"
-       y1="16.800623"
-       x2="-40.305088"
-       y2="47.029438"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient4531"
+    <radialGradient
+       cx="7.8500957"
+       cy="9.9571075"
+       r="12.671875"
+       fx="7.3198657"
+       fy="9.9571075"
+       id="radialGradient5521-1-50"
+       xlink:href="#linearGradient4457"
        gradientUnits="userSpaceOnUse"
-       x1="-40.305088"
-       y1="16.800623"
-       x2="-40.305088"
-       y2="47.029438"
-       gradientTransform="matrix(-1,0,0,1,-62.351775,0)" />
+       gradientTransform="matrix(0,5.918619,-11.65996,0,214.18052,-47.08672)" />
+    <linearGradient
+       id="linearGradient4457">
+      <stop
+         id="stop4459"
+         style="stop-color:#90dbec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4461"
+         style="stop-color:#42baea;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop4463"
+         style="stop-color:#4392e9;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop4465"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3337-2-2-5"
+       xlink:href="#linearGradient3688-166-749-4-0-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3339-1-4-6"
+       xlink:href="#linearGradient3688-166-749-4-0-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <radialGradient
+       gradientTransform="matrix(0,8.3467704,-16.443533,0,132.65198,-80.151144)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       id="radialGradient5521-1"
+       fy="9.9571075"
+       fx="7.3198657"
+       r="12.671875"
+       cy="9.9571075"
+       cx="7.8500957" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
+      <stop
+         id="stop3750-8-9"
+         style="stop-color:#90dbec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-2"
+         style="stop-color:#42baea;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-7-2"
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-9-3"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3381-5-4-0"
+       xlink:href="#linearGradient3924-2-2-5-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4324324,0,0,1.4362832,-66.628435,-3.9707791)" />
+    <radialGradient
+       gradientTransform="matrix(0,8.3467704,-16.443533,0,196.90204,-78.65115)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3996"
+       id="radialGradient5521-1-9"
+       fy="9.9571075"
+       fx="7.3198657"
+       r="12.671875"
+       cy="9.9571075"
+       cx="7.8500957" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3828"
+       id="linearGradient4253-9"
+       gradientUnits="userSpaceOnUse"
+       x1="20.375"
+       y1="35.816006"
+       x2="20.375"
+       y2="13.745791"
+       gradientTransform="matrix(1.5327996,0,0,1.4102564,-3.482365,-3.2564072)" />
   </defs>
   <metadata
      id="metadata6338">
@@ -304,159 +406,108 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     style="opacity:0.6"
-     id="g3712-8-2-4-4"
-     transform="matrix(1.5789502,0,0,0.7142857,-5.894751,27.928572)">
-    <rect
-       style="fill:url(#radialGradient3337-2-2);fill-opacity:1;stroke:none"
-       id="rect2801-5-5-7-9"
-       y="40"
-       x="38"
-       height="7"
-       width="5" />
-    <rect
-       style="fill:url(#radialGradient3339-1-4);fill-opacity:1;stroke:none"
-       id="rect3696-3-0-3-7"
-       transform="scale(-1,-1)"
-       y="-47"
-       x="-10"
-       height="7"
-       width="5" />
-    <rect
-       style="fill:url(#linearGradient6394);fill-opacity:1;stroke:none"
-       id="rect3700-5-6-8-4"
-       y="40"
-       x="10"
-       height="7.0000005"
-       width="28" />
-  </g>
-  <g
-     id="g4623"
-     transform="translate(63.177027,0)">
-    <rect
-       width="55"
-       height="55"
-       rx="2.8205128"
-       ry="2.8205128"
-       x="-58.677029"
-       y="4.5000019"
-       id="rect4566-9"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4616-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
-    <rect
-       width="55"
-       height="55"
-       rx="2.8205128"
-       ry="2.8205128"
-       x="-58.677029"
-       y="4.5000019"
-       id="rect4570-3"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#004471;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <path
-       inkscape:connector-curvature="0"
-       id="rect4572-2"
-       d="m -50.794063,10.141022 39.234057,0 c 1.242036,0 2.2419449,0.999914 2.2419449,2.241941 l 0,39.234067 c 0,1.242027 -0.9999089,2.241941 -2.2419449,2.241941 l -39.234057,0 c -1.242037,0 -2.241947,-0.999914 -2.241947,-2.241941 l 0,-39.234067 c 0,-1.242027 0.99991,-2.241941 2.241947,-2.241941 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fefefe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
-    <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
-       id="path4539"
-       d="m -28.134766,17.501906 0,0.5 0,6.966797 5.03125,0 0,16.601562 -5.03125,0 0,7.927735 12.960938,0 0,-31.996094 z"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
-       id="path4541"
-       d="m -47.177734,17.501906 0,31.996094 12.960937,0 0,-7.927735 -5.03125,0 0,-16.601562 5.03125,0 0,-7.466797 -0.5,0 z"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    <path
-       style="opacity:0.3;fill:#333333;stroke:#333333;stroke-width:0.99999994"
-       inkscape:connector-curvature="0"
-       d="m -27.634852,17.501829 0,6.466775 5.031998,0 0,17.60171 -5.031998,0 0,6.928686 11.960685,0 0,-30.997171 z"
-       id="path4245"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4578-4"
-       d="m -34.716496,17.501829 0,6.466775 -5.031997,0 0,17.60171 5.031997,0 0,6.928686 -11.960684,0 0,-30.997171 z"
-       inkscape:connector-curvature="0"
-       style="opacity:0.3;fill:#333333;stroke:#333333;stroke-width:0.99999994" />
-    <path
-       style="fill:url(#linearGradient4253);fill-opacity:1"
-       inkscape:connector-curvature="0"
-       d="m -27.634852,16.501551 0,6.466774 5.031998,0 0,17.601711 -5.031998,0 0,6.928685 11.960685,0 0,-30.99717 z"
-       id="path4247"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4249"
-       d="m -27.634852,16.501551 0,6.466774 5.031998,0 0,17.601711 -5.031998,0 0,6.928685 11.960685,0 0,-30.99717 z"
-       inkscape:connector-curvature="0"
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99999994" />
-    <g
-       style="opacity:0.3;fill:none;stroke:none;stroke-width:1.08245623;stroke-miterlimit:4;stroke-dasharray:none"
-       id="g4588-7"
-       transform="matrix(1.3028299,0,0,1.3028299,-125.07292,-0.33978764)">
-      <g
-         style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-         transform="matrix(0.35454545,0,0,0.35454545,49.73436,4.4363587)"
-         id="g4590-4">
-        <g
-           style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-           id="g4592-3">
-          <path
-             id="path4594-8"
-             d="m 59,27 0,14 -17,0 0,32 17,0 0,15 -32,0 0,-61 32,0 z"
-             inkscape:connector-curvature="0"
-             style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none" />
-        </g>
-      </g>
-      <g
-         style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-         transform="matrix(0.35454545,0,0,0.35454545,49.73436,4.4363587)"
-         id="g4596-4">
-        <g
-           style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none"
-           id="g4598-1">
-          <path
-             id="path4600-2"
-             d="m 99,27 0,61 -32,0 0,-15 18,0 0,-32 -18,0 0,-14 32,0 z"
-             inkscape:connector-curvature="0"
-             style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none" />
-        </g>
-      </g>
-    </g>
-    <path
-       sodipodi:nodetypes="ccccccccc"
-       id="path4584-1"
-       d="m -34.716496,16.501551 0,6.466774 -5.031997,0 0,17.601711 5.031997,0 0,6.928685 -11.960684,0 0,-30.99717 z"
-       inkscape:connector-curvature="0"
-       style="fill:url(#linearGradient4620-0);fill-opacity:1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99999994"
-       inkscape:connector-curvature="0"
-       d="m -34.716496,16.501551 0,6.466774 -5.031997,0 0,17.601711 5.031997,0 0,6.928685 -11.960684,0 0,-30.99717 z"
-       id="path4602-6"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#004471;stroke-width:0.99999994;stroke-opacity:1;marker:none;enable-background:accumulate"
-       d="m -50.794063,10.141022 39.234057,0 c 1.242036,0 2.2419449,0.999914 2.2419449,2.241941 l 0,39.234067 c 0,1.242027 -0.9999089,2.241941 -2.2419449,2.241941 l -39.234057,0 c -1.242037,0 -2.241947,-0.999914 -2.241947,-2.241941 l 0,-39.234067 c 0,-1.242027 0.99991,-2.241941 2.241947,-2.241941 z"
-       id="path4629-0"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:connector-curvature="0"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4396);stroke-width:0.99999994;marker:none;enable-background:accumulate"
-       d="m -55.856717,5.5000019 c -1.025861,0 -1.820312,0.7944512 -1.820312,1.8203125 l 0,49.3593756 c 0,1.02586 0.794451,1.820312 1.820312,1.820312 l 49.3593753,0 c 1.025861,0 1.820313,-0.794452 1.820313,-1.820312 l 0,-49.3593756 c 0,-1.0258613 -0.794452,-1.8203125 -1.820313,-1.8203125 l -49.3593753,0 z"
-       id="path4394" />
-    <path
-       id="path4504"
-       d="m -45.677734,17.501953 0,28.996094 9.960937,0 0,-4.927735 -5.03125,0 0,-19.601562 5.03125,0 0,-4.466797 -9.960937,0 z"
-       style="opacity:0.5;fill:none;fill-opacity:1;stroke:url(#linearGradient4527)"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:connector-curvature="0"
-       style="opacity:0.5;fill:none;fill-opacity:1;stroke:url(#linearGradient4531)"
-       d="m -16.674041,17.501953 0,28.996094 -9.960937,0 0,-4.927735 5.03125,0 0,-19.601562 -5.03125,0 0,-4.466797 9.960937,0 z"
-       id="path4529" />
-  </g>
+  <rect
+     width="7.8947511"
+     height="5"
+     x="54.105358"
+     y="56.5"
+     id="rect2801-5-5-7-9"
+     style="fill:url(#radialGradient3337-2-2);fill-opacity:1;stroke:none" />
+  <rect
+     width="7.8947511"
+     height="5"
+     x="-9.8947506"
+     y="-61.5"
+     transform="scale(-1,-1)"
+     id="rect3696-3-0-3-7"
+     style="fill:url(#radialGradient3339-1-4);fill-opacity:1;stroke:none" />
+  <rect
+     width="44.210606"
+     height="5.0000005"
+     x="9.8947506"
+     y="56.5"
+     id="rect3700-5-6-8-4"
+     style="fill:url(#linearGradient6394);fill-opacity:1;stroke:none" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient5521-1-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     id="rect5505-21-8-7"
+     y="4.5"
+     x="4.5"
+     ry="2.8205128"
+     rx="2.8205128"
+     height="55"
+     width="55" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#004471;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect4570-3"
+     y="4.5000019"
+     x="4.4999986"
+     ry="2.8205128"
+     rx="2.8205128"
+     height="55"
+     width="55" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path3918"
+     d="m 12.257105,10 c -1.786756,0 -3.257812,1.469111 -3.257812,3.255859 l 0,39.488282 C 8.999293,54.530889 10.470349,56 12.257105,56 l 39.486328,0 c 1.786756,0 3.25586,-1.469111 3.25586,-3.255859 l 0,-39.488282 C 54.999293,11.469111 53.530189,10 51.743433,10 l -39.486328,0 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.07000002;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     d="m 12.256411,11 39.48718,0 C 52.99364,11 54,12.006365 54,13.256405 l 0,39.48719 C 54,53.993635 52.99364,55 51.743591,55 l -39.48718,0 C 11.006361,55 10,53.993635 10,52.743595 l 0,-39.48719 C 10,12.006365 11.006361,11 12.256411,11 Z"
+     id="rect4572-2-7"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fefefe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     d="m 12.256411,9.9999999 39.48718,0 C 52.99364,9.9999999 54,11.006365 54,12.256405 l 0,39.48719 C 54,52.993635 52.99364,54 51.743591,54 l -39.48718,0 C 11.006361,54 10,52.993635 10,51.743595 l 0,-39.48719 c 0,-1.25004 1.006361,-2.2564051 2.256411,-2.2564051 z"
+     id="rect4572-2"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path4112"
+     d="m 35,16 a 1.0001,1.0001 0 0 0 -1,1 l 0,7 a 1.0001,1.0001 0 0 0 1,1 l 5,0 0,16 -5,0 a 1.0001,1.0001 0 0 0 -1,1 l 0,7 a 1.0001,1.0001 0 0 0 1,1 l 13,0 a 1.0001,1.0001 0 0 0 1,-1 l 0,-32 a 1.0001,1.0001 0 0 0 -1,-1 l -13,0 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.07000002;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-1"
+     d="m 35,17 0,7 6,0 0,18 -6,0 0,7 13,0 0,-32 z"
+     inkscape:connector-curvature="0"
+     style="opacity:0.15;fill:#000000;fill-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247"
+     d="m 35,16 0,7 6,0 0,18 -6,0 0,7 13,0 0,-32 z"
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient4253);fill-opacity:1" />
+  <path
+     id="path4594-8"
+     d="m 30.15235,17.911668 0,6.466774 -7.85251,0 0,14.781197 7.85251,0 0,6.928686 -14.781197,0 0,-28.176657 14.781197,0 z"
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none" />
+  <path
+     id="path4600-2"
+     d="m 48.628847,17.911668 0,28.176657 -14.781197,0 0,-6.928686 8.314423,0 0,-14.781197 -8.314423,0 0,-6.466774 14.781197,0 z"
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:none;stroke-width:3.05308175;stroke-miterlimit:4;stroke-dasharray:none" />
+  <path
+     id="path4394"
+     d="m 7.32031,5.5000019 c -1.025861,0 -1.820312,0.7944512 -1.820312,1.8203125 l 0,49.3593756 c 0,1.02586 0.794451,1.820312 1.820312,1.820312 l 49.359375,0 c 1.025861,0 1.820313,-0.794452 1.820313,-1.820312 l 0,-49.3593756 c 0,-1.0258613 -0.794452,-1.8203125 -1.820313,-1.8203125 l -49.359375,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4396);stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path4112-7"
+     d="m 29,16 a 1.0001,1.0001 0 0 1 1,1 l 0,7 a 1.0001,1.0001 0 0 1 -1,1 l -5,0 0,16 5,0 a 1.0001,1.0001 0 0 1 1,1 l 0,7 a 1.0001,1.0001 0 0 1 -1,1 l -13,0 a 1.0001,1.0001 0 0 1 -1,-1 l 0,-32 a 1.0001,1.0001 0 0 1 1,-1 l 13,0 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.07000002;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-1-2"
+     d="m 29,17 0,7 -6,0 0,18 6,0 0,7 -13,0 0,-32 z"
+     inkscape:connector-curvature="0"
+     style="opacity:0.15;fill:#000000;fill-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccccccc"
+     id="path4247-8"
+     d="m 29,16 0,7 -6,0 0,18 6,0 0,7 -13,0 0,-32 z"
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient4253-9);fill-opacity:1" />
 </svg>


### PR DESCRIPTION
Added updated Brackets icon to better follow the Human Interface Guidelines. 

The previous icons, though did resemble elementary OS's style, didn't completely follow the guidelines they're based on. I did my best to fix that (in all six sizes).

![64x64](https://cloud.githubusercontent.com/assets/22334721/20847728/aa0f893a-b8a5-11e6-8aac-954d417ff797.png)

Above is a clear comparison between the original and the modified version (64x64), and [here's](http://imgur.com/a/Vsm1W) a screenshot of the slingshot + plank integration.



