### PR TITLE
Added new symlinks for Whatsapp client 'whatsapp-desktop'

### DIFF
--- a/elementaryPlus/apps/128/whatsapp.svg
+++ b/elementaryPlus/apps/128/whatsapp.svg
@@ -1,0 +1,1 @@
+chrome-https___web.whatsapp.com_.svg

--- a/elementaryPlus/apps/16/whatsapp.svg
+++ b/elementaryPlus/apps/16/whatsapp.svg
@@ -1,0 +1,1 @@
+chrome-https___web.whatsapp.com_.svg

--- a/elementaryPlus/apps/24/whatsapp.svg
+++ b/elementaryPlus/apps/24/whatsapp.svg
@@ -1,0 +1,1 @@
+chrome-https___web.whatsapp.com_.svg

--- a/elementaryPlus/apps/32/whatsapp.svg
+++ b/elementaryPlus/apps/32/whatsapp.svg
@@ -1,0 +1,1 @@
+chrome-https___web.whatsapp.com_.svg

--- a/elementaryPlus/apps/48/whatsapp.svg
+++ b/elementaryPlus/apps/48/whatsapp.svg
@@ -1,0 +1,1 @@
+chrome-https___web.whatsapp.com_.svg

--- a/elementaryPlus/apps/64/whatsapp.svg
+++ b/elementaryPlus/apps/64/whatsapp.svg
@@ -1,0 +1,1 @@
+chrome-https___web.whatsapp.com_.svg


### PR DESCRIPTION
whatsapp-dektop uses 
`Icon=whatsapp`
in its .desktop file, so I've added new symlinks, named them 'whatsapp.svg' and linked them to the original icons.

I know, I also could have just changed the entry of the .desktop file but for those who don't want to change anything at that place, I think this is a good solution.